### PR TITLE
Minor updates - remove unused code and fix old name for loader

### DIFF
--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -109,18 +109,6 @@ void DigitizingController::fixZ( QgsPoint &point ) const
   }
 }
 
-QgsCoordinateTransform DigitizingController::transformer() const
-{
-  QgsCoordinateTransformContext context;
-  if ( mMapSettings )
-    context = mMapSettings->transformContext();
-
-  QgsCoordinateTransform transform( QgsCoordinateReferenceSystem( "EPSG:4326" ),
-                                    featureLayerPair().layer()->crs(),
-                                    context );
-  return transform;
-}
-
 bool DigitizingController::hasEnoughPoints() const
 {
   if ( hasLineGeometry( featureLayerPair().layer() ) )
@@ -317,15 +305,6 @@ FeatureLayerPair DigitizingController::lineOrPolygonFeature()
 FeatureLayerPair DigitizingController::featureWithoutGeometry( QgsVectorLayer *layer )
 {
   return createFeatureLayerPair( QgsGeometry(), layer );
-}
-
-QgsPoint DigitizingController::pointFeatureMapCoordinates( FeatureLayerPair pair )
-{
-  if ( !pair.layer() )
-    return QgsPoint();
-
-  QgsPointXY res = mMapSettings->mapSettings().layerToMapCoordinates( pair.layer(), QgsPoint( pair.feature().geometry().asPoint() ) );
-  return QgsPoint( res );
 }
 
 FeatureLayerPair DigitizingController::changePointGeometry( FeatureLayerPair pair, QgsPoint point, bool isGpsPoint )

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -59,7 +59,7 @@ class DigitizingController : public QObject
     //! Creates a new QgsFeature without geometry in layer. If layer is null, it creates the feature on currently edited layer
     Q_INVOKABLE FeatureLayerPair featureWithoutGeometry( QgsVectorLayer *layer = nullptr );
     //! Returns (point geom) featurePair coords in map coordinates.
-    Q_INVOKABLE QgsPoint pointFeatureMapCoordinates( FeatureLayerPair pair );
+
     //! Changes point geometry of given pair according given point.
     Q_INVOKABLE FeatureLayerPair changePointGeometry( FeatureLayerPair pair, QgsPoint point, bool isGpsPoint );
 
@@ -102,7 +102,7 @@ class DigitizingController : public QObject
 
   private:
     void fixZ( QgsPoint &point ) const; // add/remove Z coordinate based on layer wkb type
-    QgsCoordinateTransform transformer() const;
+
     bool hasEnoughPoints() const;
 
     bool mRecording = false;

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -838,11 +838,6 @@ void InputUtils::log( const QString &context, const QString &message )
   CoreUtils::log( context, message );
 }
 
-FeatureLayerPair InputUtils::featureFactory( const QgsFeature &feature, QgsVectorLayer *layer )
-{
-  return FeatureLayerPair( feature, layer );
-}
-
 const QUrl InputUtils::getThemeIcon( const QString &name )
 {
   QString path = QStringLiteral( "qrc:/%1.svg" ).arg( name );
@@ -1234,18 +1229,6 @@ QString InputUtils::dumpScreenInfo() const
   return msg;
 }
 
-QVariantMap InputUtils::createValueRelationCache( const QVariantMap &config, const QgsFeature &formFeature )
-{
-  QVariantMap valueMap;
-  const QgsValueRelationFieldFormatter::ValueRelationCache cache = QgsValueRelationFieldFormatter::createCache( config, formFeature );
-
-  for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : cache )
-  {
-    valueMap.insert( item.key.toString(), item.value );
-  }
-  return valueMap;
-}
-
 QString InputUtils::evaluateExpression( const FeatureLayerPair &pair, QgsProject *activeProject, const QString &expression )
 {
   QList<QgsExpressionContextScope *> scopes;
@@ -1257,14 +1240,6 @@ QString InputUtils::evaluateExpression( const FeatureLayerPair &pair, QgsProject
   context.setFeature( pair.feature() );
   QgsExpression expr( expression );
   return expr.evaluate( &context ).toString();
-}
-
-void InputUtils::selectFeaturesInLayer( QgsVectorLayer *layer, const QList<int> &fids, Qgis::SelectBehavior behavior )
-{
-  QgsFeatureIds qgsFids;
-  for ( const int &fid : fids )
-    qgsFids << fid;
-  layer->selectByIds( qgsFids, behavior );
 }
 
 QString InputUtils::fieldType( const QgsField &field )
@@ -1292,43 +1267,9 @@ QString InputUtils::dateTimeFieldFormat( const QString &fieldFormat )
   }
 }
 
-QModelIndex InputUtils::invalidIndex()
-{
-  return QModelIndex();
-}
-
 bool InputUtils::isFeatureIdValid( qint64 featureId )
 {
   return !FID_IS_NEW( featureId ) && !FID_IS_NULL( featureId );
-}
-
-QgsQuickMapSettings *InputUtils::setupMapSettings( QgsProject *project, QgsQuickMapSettings *settings )
-{
-  if ( !project || !settings )
-  {
-    return nullptr;
-  }
-
-  QgsLayerTree *root = project->layerTreeRoot();
-
-  // Get list of all visible and valid layers in the project
-  QList< QgsMapLayer * > allLayers;
-  foreach ( QgsLayerTreeLayer *nodeLayer, root->findLayers() )
-  {
-    if ( nodeLayer->isVisible() )
-    {
-      QgsMapLayer *layer = nodeLayer->layer();
-      if ( layer && layer->isValid() )
-      {
-        allLayers << layer;
-      }
-    }
-  }
-
-  settings->setLayers( allLayers );
-  settings->setTransformContext( project->transformContext() );
-
-  return settings;
 }
 
 QgsRectangle InputUtils::stakeoutPathExtent(

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -383,7 +383,7 @@ class InputUtils: public QObject
     static const QgsEditorWidgetSetup getEditorWidgetSetup( const QgsField &field );
     static const QgsEditorWidgetSetup getEditorWidgetSetup( const QgsField &field, const QString &widgetType, const QVariantMap &additionalArgs = QVariantMap() );
 
-    // Returns geometry type represented as string (point/linestring/polygon/nullGeo); returns empty string is geometry is unknown or layer is invalid.
+    // Returns geometry type represented as string (point/linestring/polygon/nullGeo); returns empty string if geometry is unknown or layer is invalid.
     Q_INVOKABLE static QString geometryFromLayer( QgsVectorLayer *layer );
 
     // Returns a point geometry from point feature

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -161,9 +161,6 @@ class InputUtils: public QObject
     /** Formats coordinates from point into degrees format with minutes, seconds and hemisphere */
     Q_INVOKABLE static QString degreesString( const QgsPoint &point );
 
-    //! Creates and registers custom expression functions to Input, so they can be used in default value definitions.
-    static void registerInputExpressionFunctions();
-
     /**
      * @brief Creates formatted string of difference for given tMin and tMax datetimes (in minutes, hours, ... ago).
      * Note, that tMin < tMax, otherwise arguments are invalid.
@@ -275,13 +272,6 @@ class InputUtils: public QObject
     Q_INVOKABLE static void log( const QString &context, const QString &message );
 
     /**
-      * FeatureLayerPair factory for tuple of QgsFeature and QgsVectorLayer used in QgsQUick library.
-      * \param feature QgsFeature linked to new Feature instance.
-      * \param layer QgsVectorLayer which the feature belongs to, optional.
-      */
-    Q_INVOKABLE static FeatureLayerPair featureFactory( const QgsFeature &feature, QgsVectorLayer *layer = nullptr );
-
-    /**
       * Returns QUrl to image from library's /images folder.
       */
     Q_INVOKABLE static const QUrl getThemeIcon( const QString &name );
@@ -357,16 +347,6 @@ class InputUtils: public QObject
     QString dumpScreenInfo() const;
 
     /**
-     * Creates a cache for a value relation field.
-     * This can be used to keep the value map in the local memory
-     * if doing multiple lookups in a loop.
-     * \param config The widget configuration
-     * \param formFeature The feature currently being edited with current attribute values
-     * \return A kvp list of values for the widget
-     */
-    Q_INVOKABLE static QVariantMap createValueRelationCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature() );
-
-    /**
      * Evaluates expression.
      * \param pair Used to define a context scope.
      * \param activeProject Used to define a context scope.
@@ -374,15 +354,6 @@ class InputUtils: public QObject
      * \return Evaluated expression
      */
     Q_INVOKABLE static QString evaluateExpression( const FeatureLayerPair &pair, QgsProject *activeProject, const QString &expression );
-
-    /**
-     * Selects features in a layer
-     * This method is required since QML cannot perform the conversion of a feature ID to a QgsFeatureId (i.e. a qint64)
-     * \param layer the vector layer
-     * \param fids the list of feature IDs
-     * \param behavior the selection behavior
-     */
-    Q_INVOKABLE static void selectFeaturesInLayer( QgsVectorLayer *layer, const QList<int> &fids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 
 
     /**
@@ -392,7 +363,6 @@ class InputUtils: public QObject
     */
     Q_INVOKABLE static QString fieldType( const QgsField &field );
 
-
     /**
     * Returns field format's name for given string representing field format defined in QgsDateTimeFieldFormatter.
     * \param fieldFormat string representing formats from QgsDateTimeFieldFormatter.
@@ -400,20 +370,9 @@ class InputUtils: public QObject
     Q_INVOKABLE static QString dateTimeFieldFormat( const QString &fieldFormat );
 
     /**
-     * \brief invalidIndex returns invalid index
-     */
-    Q_INVOKABLE static QModelIndex invalidIndex();
-
-    /**
      * Returns if provided Id is valid ( >= 0 )
      */
     Q_INVOKABLE static bool isFeatureIdValid( qint64 featureId );
-
-    /**
-     * \brief setupMapSettings sets visible layers and transform context for map settings based on project
-     * \return map settings with layers and transform context set
-     */
-    Q_INVOKABLE static QgsQuickMapSettings *setupMapSettings( QgsProject *project, QgsQuickMapSettings *settings );
 
     /**
      * Returns widget setup according the field type - supports only basic types.
@@ -424,7 +383,7 @@ class InputUtils: public QObject
     static const QgsEditorWidgetSetup getEditorWidgetSetup( const QgsField &field );
     static const QgsEditorWidgetSetup getEditorWidgetSetup( const QgsField &field, const QString &widgetType, const QVariantMap &additionalArgs = QVariantMap() );
 
-    // Returns geometry type in form that qml understands
+    // Returns geometry type represented as string (point/linestring/polygon/nullGeo); returns empty string is geometry is unknown or layer is invalid.
     Q_INVOKABLE static QString geometryFromLayer( QgsVectorLayer *layer );
 
     // Returns a point geometry from point feature

--- a/app/qml/StakeoutPanel.qml
+++ b/app/qml/StakeoutPanel.qml
@@ -227,7 +227,7 @@ Item {
             width: parent.width / 2
 
             titleText: qsTr( "Feature" )
-            text: root.targetPair ? __inputUtils.featureTitle( root.targetPair, __loader.project ) : ""
+            text: root.targetPair ? __inputUtils.featureTitle( root.targetPair, __activeProject.qgsProject ) : ""
 
             titleComponent.wrapMode: Text.NoWrap
             titleComponent.elide: Text.ElideRight


### PR DESCRIPTION
PR just removes some old unused code and fixes one place (stakeout panel) that still referenced `__loader` instead of `__activeProject`