### PR TITLE
Add maptools - Refactoring of digitizing controller & splitting map tool

### DIFF
--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -44,6 +44,8 @@ class QgsFeature;
 class QgsVectorLayer;
 class QgsCoordinateReferenceSystem;
 
+class VariablesManager;
+
 class InputUtils: public QObject
 {
     Q_OBJECT
@@ -184,6 +186,11 @@ class InputUtils: public QObject
       * Creates QgsPoint in QML
       */
     Q_INVOKABLE static QgsPoint point( double x, double y, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() );
+
+    /**
+     * Creates empty geometry
+     */
+    Q_INVOKABLE static QgsGeometry emptyGeometry();
 
     /**
       * Converts QGeoCoordinate to QgsPoint
@@ -385,6 +392,10 @@ class InputUtils: public QObject
 
     // Returns geometry type represented as string (point/linestring/polygon/nullGeo); returns empty string if geometry is unknown or layer is invalid.
     Q_INVOKABLE static QString geometryFromLayer( QgsVectorLayer *layer );
+    Q_INVOKABLE static bool isPointLayer( QgsVectorLayer *layer );
+    Q_INVOKABLE static bool isLineLayer( QgsVectorLayer *layer );
+    Q_INVOKABLE static bool isPolygonLayer( QgsVectorLayer *layer );
+    Q_INVOKABLE static bool isNoGeometryLayer( QgsVectorLayer *layer );
 
     // Returns a point geometry from point feature
     Q_INVOKABLE static QgsPointXY extractPointFromFeature( const FeatureLayerPair &feature );
@@ -403,6 +414,9 @@ class InputUtils: public QObject
 
     // Returns the title of the feature
     Q_INVOKABLE static QString featureTitle( const FeatureLayerPair &pair, QgsProject *project );
+
+    //! Creates featureLayerPair from geometry and layer, evaluates its expressions and returns it.
+    Q_INVOKABLE static FeatureLayerPair createFeatureLayerPair( QgsVectorLayer *layer, const QgsGeometry &geometry, VariablesManager *variablesmanager );
 
     // Calculates real screen DPR based on DPI
     static qreal calculateScreenDpr();

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -101,6 +101,7 @@
 
 #include "maptools/abstractmaptool.h"
 #include "maptools/recordingmaptool.h"
+#include "maptools/splittingmaptool.h""
 
 #ifndef NDEBUG
 // #include <QQmlDebuggingEnabler>
@@ -305,6 +306,7 @@ void initDeclarative()
   // map tools
   qmlRegisterUncreatableType< AbstractMapTool >( "lc", 1, 0, "AbstractMapTool", "Instantiate one of child map tools instead" );
   qmlRegisterType< RecordingMapTool >( "lc", 1, 0, "RecordingMapTool" );
+  qmlRegisterType< SplittingMapTool >( "lc", 1, 0, "SplittingMapTool" );
 
   qmlRegisterType( QUrl( "qrc:/qgsquickmapcanvas.qml" ), "QgsQuick", 0, 1, "MapCanvas" );
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -99,6 +99,8 @@
 #include "synchronizationmanager.h"
 #include "synchronizationerror.h"
 
+#include "maptools/abstractmaptool.h"
+#include "maptools/recordingmaptool.h"
 
 #ifndef NDEBUG
 // #include <QQmlDebuggingEnabler>
@@ -299,6 +301,10 @@ void initDeclarative()
   qmlRegisterType< QgsQuickCoordinateTransformer >( "QgsQuick", 0, 1, "CoordinateTransformer" );
 
   qmlRegisterUncreatableType< AbstractPositionProvider >( "lc", 1, 0, "PositionProvider", "Must be instantiated via its construct method" );
+
+  // map tools
+  qmlRegisterUncreatableType< AbstractMapTool >( "lc", 1, 0, "AbstractMapTool", "Instantiate one of child map tools instead" );
+  qmlRegisterType< RecordingMapTool >( "lc", 1, 0, "RecordingMapTool" );
 
   qmlRegisterType( QUrl( "qrc:/qgsquickmapcanvas.qml" ), "QgsQuick", 0, 1, "MapCanvas" );
 }

--- a/app/maptools/abstractmaptool.cpp
+++ b/app/maptools/abstractmaptool.cpp
@@ -1,0 +1,31 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "abstractmaptool.h"
+
+AbstractMapTool::AbstractMapTool( QObject *parent )
+  : QObject{parent}
+{
+
+}
+
+AbstractMapTool::~AbstractMapTool() = default;
+
+QgsQuickMapSettings *AbstractMapTool::mapSettings() const
+{
+  return mMapSettings;
+}
+
+void AbstractMapTool::setMapSettings( QgsQuickMapSettings *newMapSettings )
+{
+  if ( mMapSettings == newMapSettings )
+    return;
+  mMapSettings = newMapSettings;
+  emit mapSettingsChanged( mMapSettings );
+}

--- a/app/maptools/abstractmaptool.h
+++ b/app/maptools/abstractmaptool.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef ABSTRACTMAPTOOL_H
+#define ABSTRACTMAPTOOL_H
+
+#include <QObject>
+#include <qglobal.h>
+
+#include "qgsquickmapsettings.h"
+
+class AbstractMapTool : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
+
+  public:
+    explicit AbstractMapTool( QObject *parent = nullptr );
+    virtual ~AbstractMapTool();
+
+    QgsQuickMapSettings *mapSettings() const;
+    void setMapSettings( QgsQuickMapSettings *newMapSettings );
+
+  signals:
+
+    void mapSettingsChanged( QgsQuickMapSettings *mapSettings );
+
+  private:
+
+    QgsQuickMapSettings *mMapSettings = nullptr;
+};
+
+#endif // ABSTRACTMAPTOOL_H

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -1,0 +1,253 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "recordingmaptool.h"
+
+#include <QDebug>
+
+#include "qgsvectorlayer.h"
+#include "qgspolygon.h"
+#include "qgsvectorlayerutils.h"
+
+#include "position/positionkit.h"
+#include "variablesmanager.h"
+#include "inpututils.h"
+
+RecordingMapTool::RecordingMapTool( QObject *parent )
+  : AbstractMapTool{parent}
+{
+}
+
+RecordingMapTool::~RecordingMapTool() = default;
+
+void RecordingMapTool::addPoint( const QPointF &point )
+{
+  QgsPoint addPoint( point );
+
+  if ( mPositionKit && ( mCenteredToGPS || mRecordingType == StreamMode ) )
+  {
+    // we want to use GPS point here instead of the point from map
+    addPoint = mPositionKit->positionCoordinate();
+
+    QgsPointXY transformed = InputUtils::transformPoint(
+                               PositionKit::positionCRS(),
+                               mLayer->sourceCrs(),
+                               mLayer->transformContext(),
+                               addPoint
+                             );
+
+    addPoint.setX( transformed.x() );
+    addPoint.setY( transformed.y() );
+  }
+  else
+  {
+    // convert from device x/y screen pixels -> map CRS -> layer's CRS
+    addPoint = mapSettings()->screenToCoordinate( addPoint.toQPointF() );
+    addPoint = mapSettings()->mapSettings().mapToLayerCoordinates( mLayer, addPoint );
+  }
+
+  fixZ( addPoint );
+
+  mPoints.push_back( addPoint );
+  rebuildGeometry();
+}
+
+void RecordingMapTool::removePoint()
+{
+  if ( !mPoints.isEmpty() )
+  {
+    mPoints.pop_back();
+    rebuildGeometry();
+  }
+}
+
+bool RecordingMapTool::hasValidGeometry() const
+{
+  if ( mLayer )
+  {
+    if ( mLayer->geometryType() == QgsWkbTypes::PointGeometry )
+    {
+      return mPoints.count() == 1;
+    }
+    else if ( mLayer->geometryType() == QgsWkbTypes::LineGeometry )
+    {
+      return mPoints.count() >= 2;
+    }
+    else if ( mLayer->geometryType() == QgsWkbTypes::PolygonGeometry )
+    {
+      return mPoints.count() >= 3;
+    }
+  }
+  return false;
+}
+
+void RecordingMapTool::rebuildGeometry()
+{
+  if ( !mLayer )
+    return;
+
+  QgsGeometry geometry;
+
+  if ( mPoints.count() < 1 )
+  {
+    // pass
+  }
+  else if ( mLayer->geometryType() == QgsWkbTypes::PointGeometry )
+  {
+    geometry = QgsGeometry( mPoints[0].clone() );
+  }
+  else if ( mLayer->geometryType() == QgsWkbTypes::LineGeometry )
+  {
+    geometry = QgsGeometry::fromPolyline( mPoints );
+  }
+  else if ( mLayer->geometryType() == QgsWkbTypes::PolygonGeometry )
+  {
+    // TODO: possible place for crashes!
+
+    QgsLineString *linestring = new QgsLineString;
+    Q_FOREACH ( const QgsPoint &pt, mPoints )
+      linestring->addVertex( pt );
+
+    QgsPolygon *polygon = new QgsPolygon();
+    polygon->setExteriorRing( linestring );
+    geometry = QgsGeometry( polygon );
+  }
+
+  setRecordedGeometry( geometry );
+}
+
+void RecordingMapTool::fixZ( QgsPoint &point ) const
+{
+  if ( !mLayer )
+    return;
+
+  bool layerIs3D = QgsWkbTypes::hasZ( mLayer->wkbType() );
+  bool pointIs3D = QgsWkbTypes::hasZ( point.wkbType() );
+
+  if ( layerIs3D )
+  {
+    if ( !pointIs3D )
+    {
+      point.addZValue();
+    }
+  }
+  else /* !layerIs3D */
+  {
+    if ( pointIs3D )
+    {
+      point.dropZValue();
+    }
+  }
+}
+
+void RecordingMapTool::onPositionChanged()
+{
+  if ( mRecordingType != StreamMode )
+    return;
+
+  if ( !mPositionKit || !mPositionKit->hasPosition() )
+    return;
+
+  if ( mLastTimeRecorded.addSecs( mRecordingInterval ) <= QDateTime::currentDateTime() )
+  {
+    addPoint( QPointF() ); // addPoint will take point from GPS
+  }
+  else
+  {
+    // TODO: DigitizingController previously updated last point's position
+    // when has not yet timeouted.. do we need it?
+  }
+}
+
+// Getters / setters
+bool RecordingMapTool::centeredToGPS() const
+{
+  return mCenteredToGPS;
+}
+
+void RecordingMapTool::setCenteredToGPS( bool newCenteredToGPS )
+{
+  if ( mCenteredToGPS == newCenteredToGPS )
+    return;
+  mCenteredToGPS = newCenteredToGPS;
+  emit centeredToGPSChanged( mCenteredToGPS );
+}
+
+const RecordingMapTool::RecordingType &RecordingMapTool::recordingType() const
+{
+  return mRecordingType;
+}
+
+void RecordingMapTool::setRecordingType( const RecordingType &newRecordingType )
+{
+  if ( mRecordingType == newRecordingType )
+    return;
+  mRecordingType = newRecordingType;
+  emit recordingTypeChanged( mRecordingType );
+}
+
+int RecordingMapTool::recordingInterval() const
+{
+  return mRecordingInterval;
+}
+
+void RecordingMapTool::setRecordingInterval( int newRecordingInterval )
+{
+  if ( mRecordingInterval == newRecordingInterval )
+    return;
+  mRecordingInterval = newRecordingInterval;
+  emit recordingIntervalChanged( mRecordingInterval );
+}
+
+PositionKit *RecordingMapTool::positionKit() const
+{
+  return mPositionKit;
+}
+
+void RecordingMapTool::setPositionKit( PositionKit *newPositionKit )
+{
+  if ( mPositionKit == newPositionKit )
+    return;
+
+  if ( mPositionKit )
+    disconnect( mPositionKit, nullptr, this, nullptr );
+
+  mPositionKit = newPositionKit;
+
+  if ( mPositionKit )
+    connect( mPositionKit, &PositionKit::positionChanged, this, &RecordingMapTool::onPositionChanged );
+
+  emit positionKitChanged( mPositionKit );
+}
+
+QgsVectorLayer *RecordingMapTool::layer() const
+{
+  return mLayer;
+}
+
+void RecordingMapTool::setLayer( QgsVectorLayer *newLayer )
+{
+  if ( mLayer == newLayer )
+    return;
+  mLayer = newLayer;
+  emit layerChanged( mLayer );
+}
+
+const QgsGeometry &RecordingMapTool::recordedGeometry() const
+{
+  return mRecordedGeometry;
+}
+
+void RecordingMapTool::setRecordedGeometry( const QgsGeometry &newRecordedGeometry )
+{
+  if ( mRecordedGeometry.equals( newRecordedGeometry ) )
+    return;
+  mRecordedGeometry = newRecordedGeometry;
+  emit recordedGeometryChanged( mRecordedGeometry );
+}

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -9,8 +9,6 @@
 
 #include "recordingmaptool.h"
 
-#include <QDebug>
-
 #include "qgsvectorlayer.h"
 #include "qgspolygon.h"
 #include "qgsvectorlayerutils.h"
@@ -250,4 +248,27 @@ void RecordingMapTool::setRecordedGeometry( const QgsGeometry &newRecordedGeomet
     return;
   mRecordedGeometry = newRecordedGeometry;
   emit recordedGeometryChanged( mRecordedGeometry );
+}
+
+const QgsGeometry &RecordingMapTool::initialGeometry() const
+{
+  return mInitialGeometry;
+}
+
+void RecordingMapTool::setInitialGeometry( const QgsGeometry &newInitialGeometry )
+{
+  if ( mInitialGeometry.equals( newInitialGeometry ) )
+    return;
+
+  // We currently only support editing of points
+  if ( mLayer->geometryType() == QgsWkbTypes::PointGeometry )
+  {
+    QgsPoint point = QgsPoint( mInitialGeometry.asPoint() );
+    fixZ( point );
+
+    mPoints.clear();
+    mPoints.push_back( point );
+  }
+
+  emit initialGeometryChanged( mInitialGeometry );
 }

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -161,7 +161,7 @@ void RecordingMapTool::onPositionChanged()
   else
   {
     // TODO: DigitizingController previously updated last point's position
-    // when has not yet timeouted.. do we need it?
+    // when RecordingInterval has not yet timeouted.. do we need it?
   }
 }
 

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -50,7 +50,8 @@ class RecordingMapTool : public AbstractMapTool
     //! Adds point to the end of the recorded geometry; updates recordedGeometry afterwards
     Q_INVOKABLE void addPoint( const QPointF &point );
 
-    /** Removes last point from recorded geometry if there is at least one point
+    /**
+     *  Removes last point from recorded geometry if there is at least one point
      *  Updates recordedGeometry afterwards
      */
     Q_INVOKABLE void removePoint();

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -1,0 +1,112 @@
+﻿/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef RECORDINGMAPTOOL_H
+#define RECORDINGMAPTOOL_H
+
+#include "abstractmaptool.h"
+
+#include <QObject>
+#include <qglobal.h>
+
+#include "qgsgeometry.h"
+
+class PositionKit;
+class VariablesManager;
+class QgsVectorLayer;
+
+
+class RecordingMapTool : public AbstractMapTool
+{
+    Q_OBJECT
+
+    Q_PROPERTY( bool centeredToGPS READ centeredToGPS WRITE setCenteredToGPS NOTIFY centeredToGPSChanged )
+    Q_PROPERTY( RecordingType recordingType READ recordingType WRITE setRecordingType NOTIFY recordingTypeChanged )
+    Q_PROPERTY( int recordingInterval READ recordingInterval WRITE setRecordingInterval NOTIFY recordingIntervalChanged )
+
+    Q_PROPERTY( QgsVectorLayer *layer READ layer WRITE setLayer NOTIFY layerChanged )
+    Q_PROPERTY( PositionKit *positionKit READ positionKit WRITE setPositionKit NOTIFY positionKitChanged )
+
+    Q_PROPERTY( QgsGeometry recordedGeometry READ recordedGeometry WRITE setRecordedGeometry NOTIFY recordedGeometryChanged )
+
+  public:
+
+    enum RecordingType
+    {
+      StreamMode = 0,
+      Manual
+    };
+    Q_ENUM( RecordingType );
+
+    explicit RecordingMapTool( QObject *parent = nullptr );
+    virtual ~RecordingMapTool();
+
+    //! Adds point to the end of the recorded geometry; updates recordedGeometry afterwards
+    Q_INVOKABLE void addPoint( const QPointF &point );
+
+    /** Removes last point from recorded geometry if there is at least one point
+     *  Updates recordedGeometry afterwards
+     */
+    Q_INVOKABLE void removePoint();
+
+    //! Returns true if the captured geometry has enought points for the specified layer
+    Q_INVOKABLE bool hasValidGeometry() const;
+
+    // Getters / setters
+    bool centeredToGPS() const;
+    void setCenteredToGPS( bool newCenteredToGPS );
+
+    const RecordingType &recordingType() const;
+    void setRecordingType( const RecordingType &newRecordingType );
+
+    int recordingInterval() const;
+    void setRecordingInterval( int newRecordingInterval );
+
+    PositionKit *positionKit() const;
+    void setPositionKit( PositionKit *newPositionKit );
+
+    QgsVectorLayer *layer() const;
+    void setLayer( QgsVectorLayer *newLayer );
+
+    const QgsGeometry &recordedGeometry() const;
+    void setRecordedGeometry( const QgsGeometry &newRecordedGeometry );
+
+  signals:
+    void layerChanged( QgsVectorLayer *layer );
+    void centeredToGPSChanged( bool centeredToGPS );
+    void positionKitChanged( PositionKit *positionKit );
+    void recordedGeometryChanged( const QgsGeometry &recordedGeometry );
+    void recordingIntervalChanged( int lineRecordingInterval );
+    void recordingTypeChanged( const RecordingMapTool::RecordingType &recordingType );
+
+  public slots:
+    void onPositionChanged();
+
+  protected:
+    //! Takes the captured points and builds a QgsGeometry from it, based on layer wkb type
+    void rebuildGeometry();
+
+    //! Unifies Z coordinate of the point with current layer - drops / adds it
+    void fixZ( QgsPoint &point ) const;
+
+  private:
+    QVector<QgsPoint> mPoints;
+    QgsGeometry mRecordedGeometry = QgsGeometry();
+
+    bool mCenteredToGPS;
+    int mRecordingInterval;  // in seconds for the StreamingMode
+    RecordingType mRecordingType = Manual;
+
+    QDateTime mLastTimeRecorded;
+
+    QgsVectorLayer *mLayer = nullptr; // not owned
+    PositionKit *mPositionKit = nullptr; // not owned
+};
+
+#endif // RECORDINGMAPTOOL_H

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -21,7 +21,6 @@ class PositionKit;
 class VariablesManager;
 class QgsVectorLayer;
 
-
 class RecordingMapTool : public AbstractMapTool
 {
     Q_OBJECT
@@ -34,6 +33,9 @@ class RecordingMapTool : public AbstractMapTool
     Q_PROPERTY( PositionKit *positionKit READ positionKit WRITE setPositionKit NOTIFY positionKitChanged )
 
     Q_PROPERTY( QgsGeometry recordedGeometry READ recordedGeometry WRITE setRecordedGeometry NOTIFY recordedGeometryChanged )
+
+    // When editing geometry - set this as the geometry to start with
+    Q_PROPERTY( QgsGeometry initialGeometry READ initialGeometry WRITE setInitialGeometry NOTIFY initialGeometryChanged )
 
   public:
 
@@ -78,6 +80,10 @@ class RecordingMapTool : public AbstractMapTool
     const QgsGeometry &recordedGeometry() const;
     void setRecordedGeometry( const QgsGeometry &newRecordedGeometry );
 
+    const QgsGeometry &initialGeometry() const;
+    // Fills mPoints array with points from the geometry
+    void setInitialGeometry( const QgsGeometry &newInitialGeometry );
+
   signals:
     void layerChanged( QgsVectorLayer *layer );
     void centeredToGPSChanged( bool centeredToGPS );
@@ -85,6 +91,8 @@ class RecordingMapTool : public AbstractMapTool
     void recordedGeometryChanged( const QgsGeometry &recordedGeometry );
     void recordingIntervalChanged( int lineRecordingInterval );
     void recordingTypeChanged( const RecordingMapTool::RecordingType &recordingType );
+
+    void initialGeometryChanged( const QgsGeometry &initialGeometry );
 
   public slots:
     void onPositionChanged();
@@ -98,7 +106,8 @@ class RecordingMapTool : public AbstractMapTool
 
   private:
     QVector<QgsPoint> mPoints;
-    QgsGeometry mRecordedGeometry = QgsGeometry();
+    QgsGeometry mRecordedGeometry;
+    QgsGeometry mInitialGeometry;
 
     bool mCenteredToGPS;
     int mRecordingInterval;  // in seconds for the StreamingMode

--- a/app/maptools/splittingmaptool.cpp
+++ b/app/maptools/splittingmaptool.cpp
@@ -1,0 +1,111 @@
+﻿/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "splittingmaptool.h"
+
+#include "qgsvectorlayer.h"
+
+SplittingMapTool::SplittingMapTool( QObject *parent )
+  : AbstractMapTool{parent}
+{
+
+}
+
+SplittingMapTool::~SplittingMapTool() = default;
+
+void SplittingMapTool::addPoint( const QPointF &point )
+{
+  if ( !mapSettings() || !mFeatureToSplit.isValid() )
+    return;
+
+  // convert from device x/y screen pixels -> map CRS -> layer's CRS
+  QgsPoint transformed = mapSettings()->screenToCoordinate( point );
+  transformed = mapSettings()->mapSettings().mapToLayerCoordinates( mFeatureToSplit.layer(), transformed );
+
+  mPoints.push_back( transformed );
+  rebuildGeometry();
+}
+
+void SplittingMapTool::removePoint()
+{
+  if ( !mPoints.isEmpty() )
+  {
+    mPoints.pop_back();
+    rebuildGeometry();
+  }
+}
+
+bool SplittingMapTool::hasValidGeometry() const
+{
+  return mPoints.count() >= 2;
+}
+
+bool SplittingMapTool::commitSplit() const
+{
+  if ( !mFeatureToSplit.isValid() )
+    return false;
+
+  if ( !hasValidGeometry() )
+    return false;
+
+  // only the specified featureToSplit shall be split, so we select
+  // it here in order to avoid other features being split
+  mFeatureToSplit.layer()->select( mFeatureToSplit.feature().id() );
+  mFeatureToSplit.layer()->startEditing();
+
+  Qgis::GeometryOperationResult result = mFeatureToSplit.layer()->splitFeatures( mPoints );
+
+  mFeatureToSplit.layer()->commitChanges();
+  mFeatureToSplit.layer()->deselect( mFeatureToSplit.feature().id() );
+
+  if ( result == Qgis::GeometryOperationResult::Success )
+  {
+    return true;
+  }
+  return false;
+}
+
+void SplittingMapTool::rebuildGeometry()
+{
+  QgsGeometry geometry;
+
+  if ( mPoints.count() > 1 )
+  {
+    geometry = QgsGeometry::fromPolyline( mPoints );
+  }
+
+  setRecordedGeometry( geometry );
+}
+
+// Getters / setters
+const QgsGeometry &SplittingMapTool::recordedGeometry() const
+{
+  return mRecordedGeometry;
+}
+
+void SplittingMapTool::setRecordedGeometry( const QgsGeometry &newRecordedGeometry )
+{
+  if ( mRecordedGeometry.equals( newRecordedGeometry ) )
+    return;
+  mRecordedGeometry = newRecordedGeometry;
+  emit recordedGeometryChanged( mRecordedGeometry );
+}
+
+const FeatureLayerPair &SplittingMapTool::featureToSplit() const
+{
+  return mFeatureToSplit;
+}
+
+void SplittingMapTool::setFeatureToSplit( const FeatureLayerPair &newFeatureToSplit )
+{
+  if ( mFeatureToSplit == newFeatureToSplit )
+    return;
+  mFeatureToSplit = newFeatureToSplit;
+  emit featureToSplitChanged( mFeatureToSplit );
+}

--- a/app/maptools/splittingmaptool.h
+++ b/app/maptools/splittingmaptool.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SPLITTINGMAPTOOL_H
+#define SPLITTINGMAPTOOL_H
+
+#include "abstractmaptool.h"
+#include <qglobal.h>
+
+#include "qgsgeometry.h"
+
+#include "featurelayerpair.h"
+
+class SplittingMapTool : public AbstractMapTool
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QgsGeometry recordedGeometry READ recordedGeometry WRITE setRecordedGeometry NOTIFY recordedGeometryChanged )
+    Q_PROPERTY( FeatureLayerPair featureToSplit READ featureToSplit WRITE setFeatureToSplit NOTIFY featureToSplitChanged )
+
+  public:
+    explicit SplittingMapTool( QObject *parent = nullptr );
+    virtual ~SplittingMapTool();
+
+    //! Adds point to the end of the recorded geometry; updates recordedGeometry afterwards
+    Q_INVOKABLE void addPoint( const QPointF &point );
+
+    /**
+     *  Removes last point from recorded geometry if there is at least one point
+     *  Updates recordedGeometry afterwards
+     */
+    Q_INVOKABLE void removePoint();
+
+    //! Returns true if the captured geometry has enought points for the specified layer
+    Q_INVOKABLE bool hasValidGeometry() const;
+
+    /**
+     * Splits the feature with recorded geometry and commits the changes to the layer
+     * Returns true if splitting was successful, false otherwise
+     */
+    Q_INVOKABLE bool commitSplit() const;
+
+    // Getters/setters
+    const QgsGeometry &recordedGeometry() const;
+    void setRecordedGeometry( const QgsGeometry &newRecordedGeometry );
+
+    const FeatureLayerPair &featureToSplit() const;
+    void setFeatureToSplit( const FeatureLayerPair &newFeatureToSplit );
+
+  signals:
+    void recordedGeometryChanged( const QgsGeometry &recordedGeometry );
+    void featureToSplitChanged( const FeatureLayerPair &featureToSplit );
+
+  protected:
+    void rebuildGeometry();
+
+  private:
+    QVector<QgsPoint> mPoints;
+
+    QgsGeometry mRecordedGeometry;
+    FeatureLayerPair mFeatureToSplit;
+};
+
+#endif // SPLITTINGMAPTOOL_H

--- a/app/position/mapposition.cpp
+++ b/app/position/mapposition.cpp
@@ -105,7 +105,7 @@ void MapPosition::recalculateMapPosition()
     {
       QgsPointXY srcPoint = QgsPointXY( geoposition.x(), geoposition.y() );
       QgsPointXY mapPositionXY = InputUtils::transformPoint(
-                                   mPositionKit->positionCRS(),
+                                   PositionKit::positionCRS(),
                                    mMapSettings->destinationCrs(),
                                    mMapSettings->transformContext(),
                                    srcPoint

--- a/app/position/positionkit.cpp
+++ b/app/position/positionkit.cpp
@@ -29,7 +29,7 @@ PositionKit::PositionKit( QObject *parent )
 {
 }
 
-QgsCoordinateReferenceSystem PositionKit::positionCRS() const
+QgsCoordinateReferenceSystem PositionKit::positionCRS()
 {
   return QgsCoordinateReferenceSystem::fromEpsgId( 4326 );
 }

--- a/app/position/positionkit.h
+++ b/app/position/positionkit.h
@@ -73,9 +73,6 @@ class PositionKit : public QObject
     //! Creates new position kit
     explicit PositionKit( QObject *parent = nullptr );
 
-    // Coordinate reference system of position - WGS84 (constant)
-    Q_INVOKABLE QgsCoordinateReferenceSystem positionCRS() const;
-
     Q_INVOKABLE void startUpdates();
     Q_INVOKABLE void stopUpdates();
 
@@ -107,6 +104,9 @@ class PositionKit : public QObject
     void setPositionProvider( AbstractPositionProvider *newPositionProvider );
 
     double hdop() const;
+
+    // Coordinate reference system of position - WGS84 (constant)
+    Q_INVOKABLE static QgsCoordinateReferenceSystem positionCRS();
 
     Q_INVOKABLE static AbstractPositionProvider *constructProvider( const QString &type, const QString &id, const QString &name = QString() );
     Q_INVOKABLE static AbstractPositionProvider *constructActiveProvider( AppSettings *appsettings );

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -9,6 +9,7 @@ attributes/attributetabproxymodel.cpp \
 attributes/rememberattributescontroller.cpp \
 attributes/fieldvalidator.cpp \
 maptools/abstractmaptool.cpp \
+maptools/splittingmaptool.cpp \
 maptools/recordingmaptool.cpp \
 position/abstractpositionprovider.cpp \
 position/internalpositionprovider.cpp \
@@ -65,6 +66,7 @@ attributes/attributetabproxymodel.h \
 attributes/rememberattributescontroller.h \
 attributes/fieldvalidator.h \
 maptools/abstractmaptool.h \
+maptools/splittingmaptool.h \
 maptools/recordingmaptool.h \
 position/abstractpositionprovider.h \
 position/internalpositionprovider.h \

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -8,6 +8,8 @@ attributes/attributetabmodel.cpp \
 attributes/attributetabproxymodel.cpp \
 attributes/rememberattributescontroller.cpp \
 attributes/fieldvalidator.cpp \
+maptools/abstractmaptool.cpp \
+maptools/recordingmaptool.cpp \
 position/abstractpositionprovider.cpp \
 position/internalpositionprovider.cpp \
 position/mapposition.cpp \
@@ -62,6 +64,8 @@ attributes/attributetabmodel.h \
 attributes/attributetabproxymodel.h \
 attributes/rememberattributescontroller.h \
 attributes/fieldvalidator.h \
+maptools/abstractmaptool.h \
+maptools/recordingmaptool.h \
 position/abstractpositionprovider.h \
 position/internalpositionprovider.h \
 position/mapposition.h \


### PR DESCRIPTION
This PR completely rewrites `DigitizingController`, there is a separate class for it now called `RecordingMapTool`. 
I have not yet removed the `DigitizingController`, it is still used inside QML.

Our current _"digitizing"_ process is a bit of spaghetti 🍝 ,  this is a first improvement out of few (next one `Highlight.qml` and `MapWrapper.qml`)

There are two TODOs in code I need to figure out, maybe @wonder-sk could help me there? 🙏🏻 (: 

The basic idea how the digitizing is going to work:
 - `RecordingMapTools` will be instantiated from QML only for the time of recording a new feature (previously 🆙 all the time)
 - `RecordingMapTools` holds recorded points, can add and remove them; on each change generates new `QgsGeometry ~ recordedGeometry` that will be used by `Highlight.qml` to show the feature on a map
 - At the end of recording (when user hits _Done_ ), QML will take the geometry and pass it together with _layer_ and `VariablesManager` to `InputUtils::createFetureLayerPair`
 - `RecordingMapTools` is then destroyed 💣 

Moreover, there is `AbstractMapTool` that will be reused as a base class for other map tools like the tool for splitting, editing or measuring.

Update
----

This PR now also includes `SplittingMapTool`, it works similar way to `RecordingMapTool`, but in a simplified terms. It only captures geometry (add/remove point) and in the end calls `QgsVectorLayer::splitFeatures` with the captured geometry in order to split specified feature.

Behavior of copying the data is the same as in QGIS.
