### PR TITLE
Fix iOS CI

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -190,15 +190,15 @@ jobs:
           split-by: '-'
 
       - name: Create build system with qmake
+        env:
+          VERSIONS_MIN: 2 # min version to start CF_BUNDLE_VERSION with, as previously we differentiated the number based on branch name
         run: |
           INPUT_DIR=`pwd`
 
           # patch the Info.plist
           CF_BUNDLE_SHORT_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $INPUT_DIR/app/ios/Info.plist`
           TIMESTAMP=`date "+%y%m%d%H%M%S"`
-          GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
-          BRANCH_NUMBER=`if [ "X$GIT_BRANCH_NAME" == "Xmaster" ]; then echo "2"; else echo "1"; fi`
-          CF_BUNDLE_VERSION=${BRANCH_NUMBER}.${{ steps.split.outputs._2 }}.${TIMESTAMP}
+          CF_BUNDLE_VERSION=${VERSIONS_MIN}.${{ steps.split.outputs._2 }}.${TIMESTAMP}
 
           echo "Building version: $CF_BUNDLE_VERSION"
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_BUNDLE_VERSION" "$INPUT_DIR/app/ios/Info.plist"


### PR DESCRIPTION
New builds submitted to Apple now need to have the `CF_BUNDLE_VERSION` higher than any previously sent builds. 
We used to compare branch names and based on that set the initial number, like this: `1(PR build)/2(build on master).xx.yyy`.

I changed it to `2.xx.yyy`, where 2 is constant, `xx` is INPUT_SDK build number and `yyy` is timestamp.

Resolves #2104 
Resolves #1786 

CU-2h19u7b