### PR TITLE
Ignore QT and Input-SDK in CI coverall check

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           cd build-Input
           lcov --directory . --capture --output-file coverage.info
-          lcov --remove coverage.info '*/merginsecrets.cpp' '*/test/*' '/usr/*' '/Applications/*' '/opt/*' '*build-Input/*' --output-file coverage.info
+          lcov --remove coverage.info '*input-sdk/*' '*Qt/*' '*/merginsecrets.cpp' '*/test/*' '/usr/*' '/Applications/*' '/opt/*' '*build-Input/*' --output-file coverage.info
           lcov --list coverage.info
 
       - name: Coveralls


### PR DESCRIPTION
Resolves #1789 