### PR TITLE
Initialize snapping properties

### DIFF
--- a/app/snaputils.h
+++ b/app/snaputils.h
@@ -103,9 +103,9 @@ class SnapUtils : public QObject
     QgsSnappingUtils mSnappingUtils;
     QPointF mCenterPosition = QPointF( -1, -1 );
     QgsPoint mRecordPoint = QgsPoint( -1, -1 );
-    bool mSnapped;
+    bool mSnapped = false;
     SnapType mSnapType = SnapUtils::Vertex;
-    bool mUseSnapping;
+    bool mUseSnapping = false;
     QgsVectorLayer *mDestinationLayer = nullptr;
 };
 


### PR DESCRIPTION
As can be seen on the video: https://lutraconsulting.slack.com/files/UT782RCHE/F03N0SD7TSM/recordit-1656507059.mp4 crosshair was invisible when "splitting" started. It was due to uninitialised properties.