### PR TITLE
Fix linux broken curl link

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
+            sudo apt-get install libcurl4-gnutls-dev
             sudo apt-get install -y bison ca-certificates ccache cmake cmake-curses-gui dh-python expect flex flip gdal-bin \
                             git graphviz libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgeos++-dev \
                             libgsl-dev libpq-dev libproj-dev libprotobuf-dev \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
+            sudo apt-get update -y
             sudo apt-get install libcurl4-gnutls-dev
             sudo apt-get install -y bison ca-certificates ccache cmake cmake-curses-gui dh-python expect flex flip gdal-bin \
                             git graphviz libexiv2-dev libexpat1-dev libfcgi-dev libgdal-dev libgeos-dev libgeos++-dev \


### PR DESCRIPTION
Linux CI build tried to install the `libcurl4-gnutls-dev` as part of some dependency. This lib was, however, unavailable until `apt-get update` runs.