### PR TITLE
Change email address for users created in autotests

### DIFF
--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -36,7 +36,7 @@ void TestUtils::mergin_auth( MerginApi *api, QString &apiRoot, QString &username
     // we need to register new user for tests and assign its credentials to env vars
     username = generateUsername();
     password = generatePassword();
-    QString email = username + "@autotest.xy";
+    QString email = username + "@lutraconsulting.co.uk";
 
     qDebug() << "REGISTERING NEW TEST USER:" << username;
 
@@ -61,7 +61,7 @@ QString TestUtils::generateUsername()
 {
   QDateTime time = QDateTime::currentDateTime();
   QString uniqename = time.toString( QStringLiteral( "ddMMyyyy-hhmmss-z" ) );
-  return QStringLiteral( "input-%1" ).arg( uniqename );
+  return QStringLiteral( "mergin+autotest+%1" ).arg( uniqename );
 }
 
 QString TestUtils::generatePassword()

--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -60,8 +60,8 @@ void TestUtils::mergin_auth( MerginApi *api, QString &apiRoot, QString &username
 QString TestUtils::generateUsername()
 {
   QDateTime time = QDateTime::currentDateTime();
-  QString uniqename = time.toString( QStringLiteral( "ddMMyyyy-hhmmss-z" ) );
-  return QStringLiteral( "mergin+autotest+%1" ).arg( uniqename );
+  QString uniqename = time.toString( QStringLiteral( "ddMMyy-hhmmss" ) );
+  return QStringLiteral( "mergin+test+%1" ).arg( uniqename );
 }
 
 QString TestUtils::generatePassword()

--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -36,7 +36,7 @@ void TestUtils::mergin_auth( MerginApi *api, QString &apiRoot, QString &username
     // we need to register new user for tests and assign its credentials to env vars
     username = generateUsername();
     password = generatePassword();
-    QString email = username + "@lutraconsulting.co.uk";
+    QString email = generateEmail();
 
     qDebug() << "REGISTERING NEW TEST USER:" << username;
 
@@ -60,8 +60,15 @@ void TestUtils::mergin_auth( MerginApi *api, QString &apiRoot, QString &username
 QString TestUtils::generateUsername()
 {
   QDateTime time = QDateTime::currentDateTime();
-  QString uniqename = time.toString( QStringLiteral( "ddMMyy-hhmmss" ) );
-  return QStringLiteral( "mergin+test+%1" ).arg( uniqename );
+  QString uniqename = time.toString( QStringLiteral( "ddMMyy-hhmmss-z" ) );
+  return QStringLiteral( "input-%1" ).arg( uniqename );
+}
+
+QString TestUtils::generateEmail()
+{
+  QDateTime time = QDateTime::currentDateTime();
+  QString uniqename = time.toString( QStringLiteral( "ddMMyy-hhmmss-z" ) );
+  return QStringLiteral( "mergin+autotest+%1@lutraconsulting.co.uk" ).arg( uniqename );
 }
 
 QString TestUtils::generatePassword()

--- a/app/test/testutils.h
+++ b/app/test/testutils.h
@@ -23,6 +23,7 @@ namespace TestUtils
   void mergin_auth( MerginApi *api, QString &apiRoot, QString &username, QString &password );
 
   QString generateUsername();
+  QString generateEmail();
   QString generatePassword();
 
   QString testDataDir();


### PR DESCRIPTION
Changes email address for autotest users from (non-existing) `@autotest.xy` domain to our domain. Emails can be filtered via `+`.