### PR TITLE
[GEOEDIT] catch mouse clicks in RecordingTools

### DIFF
--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -197,6 +197,13 @@ Item {
     function onUserInteractedWithMap() {
       mapTool.centeredToGPS = false
     }
+
+    function onClicked( point ) {
+      let screenPoint = Qt.point( point.x, point.y )
+
+      // TODO: pass the screenpoint to RecordingMapTool
+      // mapTool.lookForVertex( screenPoint )
+    }
   }
 
   Component.onCompleted: {


### PR DESCRIPTION
Simply listens on `clicked` signal of map canvas in `RecordingTools`