### PR TITLE
[GEOEDIT] Alter guideline - move vertex with crosshair

### DIFF
--- a/app/guidelinecontroller.h
+++ b/app/guidelinecontroller.h
@@ -16,6 +16,8 @@
 #include "qgsgeometry.h"
 #include "qgsquickmapsettings.h"
 
+#include "qgsvertexid.h"
+
 class GuidelineController : public QObject
 {
     Q_OBJECT
@@ -24,6 +26,8 @@ class GuidelineController : public QObject
     Q_PROPERTY( QgsGeometry realGeometry READ realGeometry WRITE setRealGeometry NOTIFY realGeometryChanged )
     Q_PROPERTY( QPointF crosshairPosition READ crosshairPosition WRITE setCrosshairPosition NOTIFY crosshairPositionChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
+
+    Q_PROPERTY( QgsPoint name READ name WRITE setName NOTIFY nameChanged )
 
     // output properties (real geometry + crosshair position ) in map CRS
     Q_PROPERTY( QgsGeometry guidelineGeometry READ guidelineGeometry WRITE setGuidelineGeometry NOTIFY guidelineGeometryChanged )

--- a/app/guidelinecontroller.h
+++ b/app/guidelinecontroller.h
@@ -27,7 +27,7 @@ class GuidelineController : public QObject
     Q_PROPERTY( QPointF crosshairPosition READ crosshairPosition WRITE setCrosshairPosition NOTIFY crosshairPositionChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
 
-    Q_PROPERTY( QgsPoint name READ name WRITE setName NOTIFY nameChanged )
+    Q_PROPERTY( QgsVertexId activeVertexId READ activeVertexId WRITE setActiveVertexId NOTIFY activeVertexIdChanged )
 
     // output properties (real geometry + crosshair position ) in map CRS
     Q_PROPERTY( QgsGeometry guidelineGeometry READ guidelineGeometry WRITE setGuidelineGeometry NOTIFY guidelineGeometryChanged )
@@ -47,6 +47,9 @@ class GuidelineController : public QObject
     QgsQuickMapSettings *mapSettings() const;
     void setMapSettings( QgsQuickMapSettings *newMapSettings );
 
+    const QgsVertexId &activeVertexId() const;
+    void setActiveVertexId( const QgsVertexId &newActiveVertexId );
+
   signals:
 
     void guidelineGeometryChanged( const QgsGeometry &guidelineGeometry );
@@ -56,6 +59,8 @@ class GuidelineController : public QObject
 
     void mapSettingsChanged( QgsQuickMapSettings *mapSettings );
 
+    void activeVertexIdChanged( const QgsVertexId &activeVertexId );
+
   private:
     void buildGuideline();
 
@@ -63,6 +68,7 @@ class GuidelineController : public QObject
     QPointF mCrosshairPosition;
     QgsGeometry mRealGeometry;
     QgsQuickMapSettings *mMapSettings = nullptr; // not owned
+    QgsVertexId mActiveVertexId;
 };
 
 #endif // GUIDELINECONTROLLER_H


### PR DESCRIPTION
This needs a lot of testing, but it can be an initial skeleton.

`GuidelineController` has activeVertexId to know which vertex to move in guideline, it changes its position to crosshair position.