### PR TITLE
recording tool and toolbar updates

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1763,7 +1763,8 @@ QgsGeometry InputUtils::createGeometryForLayer( QgsVectorLayer *layer )
 
     case QgsWkbTypes::Polygon:
     {
-      QgsPolygon *polygon = new QgsPolygon();
+      QgsLineString *line = new QgsLineString();
+      QgsPolygon *polygon = new QgsPolygon( line );
       geometry.set( polygon );
       break;
     }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -33,6 +33,11 @@
 #include "qgslayertree.h"
 #include "qgsprojectviewsettings.h"
 #include "qgsvectorlayerutils.h"
+#include "qgslinestring.h"
+#include "qgspolygon.h"
+#include "qgsmultipoint.h"
+#include "qgsmultilinestring.h"
+#include "qgsmultipolygon.h"
 
 #include "featurelayerpair.h"
 #include "qgsquickmapsettings.h"
@@ -1728,4 +1733,65 @@ bool InputUtils::rescaleImage( const QString &path, QgsProject *activeProject )
 {
   int quality = activeProject->readNumEntry( QStringLiteral( "Mergin" ), QStringLiteral( "PhotoQuality" ), 0 );
   return ImageUtils::rescale( path, quality );
+}
+
+
+QgsGeometry InputUtils::createGeometryForLayer( QgsVectorLayer *layer )
+{
+  QgsGeometry geometry;
+
+  if ( !layer )
+  {
+    return geometry;
+  }
+
+  switch ( layer->wkbType() )
+  {
+    case QgsWkbTypes::Point:
+    {
+      QgsPoint *point = new QgsPoint();
+      geometry.set( point );
+      break;
+    }
+
+    case QgsWkbTypes::LineString:
+    {
+      QgsLineString *line = new QgsLineString();
+      geometry.set( line );
+      break;
+    }
+
+    case QgsWkbTypes::Polygon:
+    {
+      QgsPolygon *polygon = new QgsPolygon();
+      geometry.set( polygon );
+      break;
+    }
+
+    case QgsWkbTypes::MultiPoint:
+    {
+      QgsMultiPoint *multiPoint = new QgsMultiPoint();
+      geometry.set( multiPoint );
+      break;
+    }
+
+    case QgsWkbTypes::MultiLineString:
+    {
+      QgsMultiLineString *multiLine = new QgsMultiLineString();
+      geometry.set( multiLine );
+      break;
+    }
+
+    case QgsWkbTypes::MultiPolygon:
+    {
+      QgsMultiPolygon *multiPolygon = new QgsMultiPolygon();
+      geometry.set( multiPolygon );
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return geometry;
 }

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -477,6 +477,12 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static bool rescaleImage( const QString &path, QgsProject *activeProject );
 
+    /**
+     * Creates an empty geometry matching layer WKB type
+     */
+    Q_INVOKABLE static QgsGeometry createGeometryForLayer( QgsVectorLayer *layer );
+
+
   signals:
     Q_INVOKABLE void showNotificationRequested( const QString &message );
 

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -50,7 +50,7 @@ void RecordingMapTool::addPoint( const QgsPoint &point )
   fixZ( pointToAdd );
 
   QgsVertexId id( 0, 0, 0 );
-  if ( mRecordedGeometry.wkbType() == QgsWkbTypes::Unknown )
+  if ( mRecordedGeometry.isEmpty() )
   {
     mRecordedGeometry = InputUtils::createGeometryForLayer( mLayer );
   }
@@ -61,17 +61,15 @@ void RecordingMapTool::addPoint( const QgsPoint &point )
 
   mRecordedGeometry.get()->insertVertex( id, pointToAdd );
   emit recordedGeometryChanged( mRecordedGeometry );
-  //createNodesAndHandles();
 }
 
 void RecordingMapTool::removePoint()
 {
-  if ( !mRecordedGeometry.isEmpty() )
+  if ( mRecordedGeometry.constGet()->vertexCount() > 0 )
   {
     QgsVertexId id( 0, 0, mRecordedGeometry.constGet()->vertexCount() - 1 );
     mRecordedGeometry.get()->deleteVertex( id );
     emit recordedGeometryChanged( mRecordedGeometry );
-    //createNodesAndHandles();
   }
 }
 
@@ -150,7 +148,6 @@ void RecordingMapTool::onPositionChanged()
       QgsVertexId id( 0, 0, mRecordedGeometry.constGet()->vertexCount() - 1 );
       mRecordedGeometry.get()->moveVertex( id, p );
       emit recordedGeometryChanged( mRecordedGeometry );
-      //createNodesAndHandles();
     }
   }
 }
@@ -242,7 +239,6 @@ void RecordingMapTool::setRecordedGeometry( const QgsGeometry &newRecordedGeomet
   if ( mRecordedGeometry.equals( newRecordedGeometry ) )
     return;
   mRecordedGeometry = newRecordedGeometry;
-  createNodesAndHandles();
   emit recordedGeometryChanged( mRecordedGeometry );
 }
 
@@ -259,7 +255,6 @@ void RecordingMapTool::setInitialGeometry( const QgsGeometry &newInitialGeometry
   mInitialGeometry = newInitialGeometry;
 
   setRecordedGeometry( newInitialGeometry );
-  createNodesAndHandles();
 
   emit initialGeometryChanged( mInitialGeometry );
 }
@@ -412,6 +407,17 @@ void RecordingMapTool::setClickedVertexId( QgsVertexId newId )
   emit clickedVertexIdChanged( mClickedVertexId );
 }
 
+QgsPoint &RecordingMapTool::clickedPoint()
+{
+  return mClickedPoint;
+}
+
+void RecordingMapTool::setClickedPoint( QgsPoint newPoint )
+{
+  mClickedPoint = newPoint;
+  emit clickedPointChanged( mClickedPoint );
+}
+
 void RecordingMapTool::lookForVertex( const QPointF &clickedPoint, double searchRadius )
 {
   double minDistance = std::numeric_limits<double>::max();
@@ -436,10 +442,12 @@ void RecordingMapTool::lookForVertex( const QPointF &clickedPoint, double search
       vertexId.part = pair.first.part;
       vertexId.ring = pair.first.ring;
       vertexId.vertex = pair.first.vertex;
+      point = pair.second;
     }
   }
 
   setClickedVertexId( vertexId );
+  setClickedPoint( point );
 }
 
 void RecordingMapTool::removeVertex()

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -461,34 +461,49 @@ void RecordingMapTool::lookForVertex( const QPointF &clickedPoint, double search
   setClickedVertexId( vertexId );
 }
 
-void RecordingMapTool::removeVertex( QgsVertexId id )
+void RecordingMapTool::removeVertex()
 {
-  QgsGeometry geometry;
-  QgsAbstractGeometry *geom = mRecordedGeometry.get()->clone();
+  if ( !mClickedVertexId.isValid() )
+  {
+    return;
+  }
 
-  if ( geom->deleteVertex( id ) )
+  QgsGeometry geometry;
+  QgsAbstractGeometry *geom = mRecordedGeometry.get();
+
+  if ( geom->deleteVertex( mClickedVertexId ) )
     geometry.set( geom );
 
   setRecordedGeometry( geometry );
 }
 
-void RecordingMapTool::insertVertex( QgsVertexId id, const QgsPoint &point )
+void RecordingMapTool::insertVertex( const QgsPoint &point )
 {
-  QgsGeometry geometry;
-  QgsAbstractGeometry *geom = mRecordedGeometry.get()->clone();
+  if ( !mClickedVertexId.isValid() )
+  {
+    return;
+  }
 
-  if ( geom->insertVertex( id, point ) )
+  QgsGeometry geometry;
+  QgsAbstractGeometry *geom = mRecordedGeometry.get();
+
+  if ( geom->insertVertex( mClickedVertexId, point ) )
     geometry.set( geom );
 
   setRecordedGeometry( geometry );
 }
 
-void RecordingMapTool::updateVertex( QgsVertexId id, const QgsPoint &point )
+void RecordingMapTool::updateVertex( const QgsPoint &point )
 {
-  QgsGeometry geometry;
-  QgsAbstractGeometry *geom = mRecordedGeometry.get()->clone();
+  if ( !mClickedVertexId.isValid() )
+  {
+    return;
+  }
 
-  if ( geom->moveVertex( id, point ) )
+  QgsGeometry geometry;
+  QgsAbstractGeometry *geom = mRecordedGeometry.get();
+
+  if ( geom->moveVertex( mClickedVertexId, point ) )
     geometry.set( geom );
 
   setRecordedGeometry( geometry );

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -279,6 +279,9 @@ void RecordingMapTool::createNodesAndHandles()
 
   if ( mRecordedGeometry.isEmpty() )
   {
+    emit existingVerticesChanged( mExistingVertices );
+    emit midPointsChanged( mMidPoints );
+    emit handlesChanged( mHandles );
     return;
   }
 

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -155,13 +155,8 @@ class RecordingMapTool : public AbstractMapTool
     void onPositionChanged();
 
   protected:
-    //! Takes the captured points and builds a QgsGeometry from it, based on layer wkb type
-    void rebuildGeometry();
-
     //! Unifies Z coordinate of the point with current layer - drops / adds it
     void fixZ( QgsPoint &point ) const;
-
-    QVector<QgsPoint> mPoints;
 
   private:
     /**

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -43,6 +43,7 @@ class RecordingMapTool : public AbstractMapTool
 
     Q_PROPERTY( QString state READ state WRITE setState NOTIFY stateChanged )
     Q_PROPERTY( QgsVertexId clickedVertexId READ clickedVertexId WRITE setClickedVertexId NOTIFY clickedVertexIdChanged )
+    Q_PROPERTY( QgsPoint clickedPoint READ clickedPoint WRITE setClickedPoint NOTIFY clickedPointChanged )
 
   public:
 
@@ -131,6 +132,9 @@ class RecordingMapTool : public AbstractMapTool
     QgsVertexId &clickedVertexId();
     void setClickedVertexId( QgsVertexId newId );
 
+    QgsPoint &clickedPoint();
+    void setClickedPoint( QgsPoint newPoint );
+
   signals:
     void layerChanged( QgsVectorLayer *layer );
     void centeredToGPSChanged( bool centeredToGPS );
@@ -150,6 +154,7 @@ class RecordingMapTool : public AbstractMapTool
     void stateChanged( const QString &state );
 
     void clickedVertexIdChanged( QgsVertexId id );
+    void clickedPointChanged( QgsPoint point );
 
   public slots:
     void onPositionChanged();
@@ -183,6 +188,7 @@ class RecordingMapTool : public AbstractMapTool
     QString mState = "view";
     QVector< QPair<QgsVertexId, QgsPoint> > mVertexIds;
     QgsVertexId mClickedVertexId;
+    QgsPoint mClickedPoint;
 };
 
 #endif // RECORDINGMAPTOOL_H

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -77,19 +77,21 @@ class RecordingMapTool : public AbstractMapTool
     Q_INVOKABLE void lookForVertex( const QPointF &clickedPoint, double searchRadius = 0.001 );
 
     /**
-     *  Removes vertex with given id from the geometry and updates recordedGeometry
+     * Removes vertex with given id from the geometry and updates recordedGeometry
      */
-    Q_INVOKABLE void removeVertex( QgsVertexId id );
+    Q_INVOKABLE void removeVertex();
 
     /**
-     *  Inserts new vertex at the given position and updates recordedGeometry
+     * Inserts new vertex at the active vertex position and updates recordedGeometry
+     * Passed point needs to be in active vector layer CRS
      */
-    Q_INVOKABLE void insertVertex( QgsVertexId id, const QgsPoint &point );
+    Q_INVOKABLE void insertVertex( const QgsPoint &point );
 
     /**
-     *  Updates vertex at the given position and updates recordedGeometry
+     * Updates vertex at the active vertex position and updates recordedGeometry
+     * Passed point needs to be in active vector layer CRS
      */
-    Q_INVOKABLE void updateVertex( QgsVertexId id, const QgsPoint &point );
+    Q_INVOKABLE void updateVertex( const QgsPoint &point );
 
     // Getters / setters
     bool centeredToGPS() const;

--- a/app/qml/map/RecordingToolbar.qml
+++ b/app/qml/map/RecordingToolbar.qml
@@ -21,6 +21,7 @@ Item {
     id: root
 
     signal addClicked
+    signal releaseClicked
     signal cancelClicked
     signal gpsSwitchClicked
     signal gpsSwithHeld
@@ -89,7 +90,7 @@ Item {
             MainPanelButton {
                 id: removePointButton
                 width: root.itemSize
-                text: qsTr("Undo")
+                text: qsTr("Remove")
                 imageSource: InputStyle.undoIcon
                 enabled: manualRecording
 
@@ -104,7 +105,7 @@ Item {
             MainPanelButton {
                 id: addButton
                 width: root.itemSize
-                text: qsTr("Add Point")
+                text: qsTr("Add")
                 imageSource: InputStyle.plusIcon
                 enabled: manualRecording
 
@@ -113,9 +114,24 @@ Item {
         }
 
         Item {
+            height: parent.height
+            Layout.fillWidth: true
+            visible: false
+
+            MainPanelButton {
+                id: releaseButton
+                width: root.itemSize
+                text: qsTr("Release")
+                imageSource: InputStyle.plusIcon
+                enabled: manualRecording
+
+                onActivated: root.releaseClicked()
+            }
+        }
+
+        Item {
             Layout.fillWidth: true
             height: parent.height
-            visible: root.pointLayerSelected ? false : true
 
             MainPanelButton {
                 id: finishButton

--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -209,6 +209,10 @@ Item {
       }
     }
 
+    onReleaseClicked: {
+      // TODO
+    }
+
     onRemovePointClicked: mapTool.removePoint()
 
     onDoneClicked: {

--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -247,8 +247,7 @@ Item {
     function onClicked( point ) {
       let screenPoint = Qt.point( point.x, point.y )
 
-      // TODO: pass the screenpoint to RecordingMapTool
-      // mapTool.lookForVertex( screenPoint )
+      mapTool.lookForVertex( screenPoint )
     }
   }
 

--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -75,6 +75,13 @@ Item {
 
     // Bind variables manager to know if we are centered to GPS or not when evaluating position variables
     onIsUsingPositionChanged: __variablesManager.useGpsPoint = isUsingPosition
+
+    onClickedVertexIdChanged: {
+      if ( mapTool.clickedVertexId.isValid() )
+      {
+        root.map.mapSettings.setCenter( mapTool.clickedPoint );
+      }
+    }
   }
 
   GuidelineController {


### PR DESCRIPTION
More work on geometry editing support:

- update RecordingMapTool to edit geometry directly instead of rebuilding it from list of points.
- add Release button to recording toolbar and corresponding signal hanler (does nothing at the moment)
- connect RecordingMapTool with crosshair position

Small demo
![Peek 2022-07-22 09-41](https://user-images.githubusercontent.com/776954/180379240-0e8e12f5-e6a8-45f2-8234-73986d6bcbaf.gif)
