### PR TITLE
QDirIterator on Windows - Fix Windows sync

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,7 +31,7 @@ jobs:
       CCACHE_DIR: /Users/runner/work/ccache
       GITHUB_TOKEN: ${{ secrets.INPUTAPP_BOT_GITHUB_TOKEN }}
       INPUTKEYSTORE_STOREPASS: ${{ secrets.INPUTKEYSTORE_STOREPASS }}
-      CACHE_VERSION: 1
+      CACHE_VERSION: 2
 
     steps:
       - uses: actions/checkout@v2

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1788,7 +1788,10 @@ void MerginApi::pushFileReplyFinished()
     int chunkNo = currentFile.chunks.indexOf( chunkID );
     if ( chunkNo < currentFile.chunks.size() - 1 )
     {
-      pushFile( projectFullName, transactionUUID, currentFile, chunkNo + 1 );
+      QTimer::singleShot( 10000, this, [this, projectFullName, transactionUUID, currentFile, chunkNo]()
+      {
+        pushFile( projectFullName, transactionUUID, currentFile, chunkNo + 1 );
+      } );
     }
     else
     {
@@ -1800,11 +1803,17 @@ void MerginApi::pushFileReplyFinished()
       if ( !transaction.pushQueue.isEmpty() )
       {
         MerginFile nextFile = transaction.pushQueue.first();
-        pushFile( projectFullName, transactionUUID, nextFile );
+        QTimer::singleShot( 10000, this, [this, projectFullName, transactionUUID, nextFile]()
+        {
+          pushFile( projectFullName, transactionUUID, nextFile );
+        } );
       }
       else
       {
-        pushFinish( projectFullName, transactionUUID );
+        QTimer::singleShot( 10000, this, [this, projectFullName, transactionUUID]()
+        {
+          pushFinish( projectFullName, transactionUUID );
+        } );
       }
     }
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2539,6 +2539,16 @@ ProjectDiff MerginApi::compareProjectFiles(
   ProjectDiff diff;
   QHash<QString, MerginFile> oldServerFilesMap, newServerFilesMap;
 
+  qDebug() << "--- \n old server files:";
+  foreach ( MerginFile f, oldServerFiles )
+    qDebug() << f.path;
+
+  qDebug() << "--- \n local files:";
+  foreach ( MerginFile f, localFiles )
+    qDebug() << f.path;
+
+  qDebug() << "---";
+
   for ( MerginFile file : newServerFiles )
   {
     newServerFilesMap.insert( file.path, file );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2947,7 +2947,7 @@ void MerginApi::createPathIfNotExists( const QString &filePath )
 
 bool MerginApi::isInIgnore( const QFileInfo &info )
 {
-  return sIgnoreExtensions.contains( info.suffix() ) || sIgnoreFiles.contains( info.fileName() ) || info.filePath().startsWith( "/" + sMetadataFolder );
+  return sIgnoreExtensions.contains( info.suffix() ) || sIgnoreFiles.contains( info.fileName() ) || info.filePath().contains( sMetadataFolder + "/" );
 }
 
 bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &config )

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1679,16 +1679,13 @@ void MerginApi::pushStartReplyFinished()
     if ( !files.isEmpty() )
     {
       QString transactionUUID;
-      QJsonParseError error;
-      QJsonDocument doc = QJsonDocument::fromJson( data, &error );
+      QJsonDocument doc = QJsonDocument::fromJson( data );
       if ( doc.isObject() )
       {
         QJsonObject docObj = doc.object();
         transactionUUID = docObj.value( QStringLiteral( "transaction" ) ).toString();
         transaction.transactionUUID = transactionUUID;
       }
-      CoreUtils::log( "Response:", data );
-      CoreUtils::log( "JSON ERROR:", error.errorString() + error.error );
 
       if ( transaction.transactionUUID.isEmpty() )
       {
@@ -1699,7 +1696,6 @@ void MerginApi::pushStartReplyFinished()
       CoreUtils::log( "push " + projectFullName, QStringLiteral( "Push request accepted. Transaction ID: " ) + transactionUUID );
 
       MerginFile file = files.first();
-
       pushFile( projectFullName, transactionUUID, file );
       emit pushFilesStarted();
     }
@@ -2539,16 +2535,6 @@ ProjectDiff MerginApi::compareProjectFiles(
 {
   ProjectDiff diff;
   QHash<QString, MerginFile> oldServerFilesMap, newServerFilesMap;
-
-  qDebug() << "--- \n old server files:";
-  foreach ( MerginFile f, oldServerFiles )
-    qDebug() << f.path;
-
-  qDebug() << "--- \n local files:";
-  foreach ( MerginFile f, localFiles )
-    qDebug() << f.path;
-
-  qDebug() << "---";
 
   for ( MerginFile file : newServerFiles )
   {

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1678,13 +1678,16 @@ void MerginApi::pushStartReplyFinished()
     if ( !files.isEmpty() )
     {
       QString transactionUUID;
-      QJsonDocument doc = QJsonDocument::fromJson( data );
+      QJsonParseError error;
+      QJsonDocument doc = QJsonDocument::fromJson( data, &error );
       if ( doc.isObject() )
       {
         QJsonObject docObj = doc.object();
         transactionUUID = docObj.value( QStringLiteral( "transaction" ) ).toString();
         transaction.transactionUUID = transactionUUID;
       }
+      qDebug() << "Response:" << data;
+      qDebug() << "JSON ERROR:" << error.errorString() << error.error;
 
       CoreUtils::log( "push " + projectFullName, QStringLiteral( "Push request accepted. Transaction ID: " ) + transactionUUID );
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1686,8 +1686,8 @@ void MerginApi::pushStartReplyFinished()
         transactionUUID = docObj.value( QStringLiteral( "transaction" ) ).toString();
         transaction.transactionUUID = transactionUUID;
       }
-      qDebug() << "Response:" << data;
-      qDebug() << "JSON ERROR:" << error.errorString() << error.error;
+      CoreUtils::log( "Response:", data );
+      CoreUtils::log( "JSON ERROR:", error.errorString() + error.error );
 
       CoreUtils::log( "push " + projectFullName, QStringLiteral( "Push request accepted. Transaction ID: " ) + transactionUUID );
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -29,6 +29,7 @@
 #include <geodiff.h>
 
 const QString MerginApi::sMetadataFile = QStringLiteral( "/.mergin/mergin.json" );
+const QString MerginApi::sMetadataFolder = QStringLiteral( ".mergin" );
 const QString MerginApi::sMerginConfigFile = QStringLiteral( "mergin-config.json" );
 const QString MerginApi::sDefaultApiRoot = QStringLiteral( "https://app.merginmaps.com/" );
 const QSet<QString> MerginApi::sIgnoreExtensions = QSet<QString>() << "gpkg-shm" << "gpkg-wal" << "qgs~" << "qgz~" << "pyc" << "swap";
@@ -2960,7 +2961,7 @@ void MerginApi::createPathIfNotExists( const QString &filePath )
 
 bool MerginApi::isInIgnore( const QFileInfo &info )
 {
-  return sIgnoreExtensions.contains( info.suffix() ) || sIgnoreFiles.contains( info.fileName() );
+  return sIgnoreExtensions.contains( info.suffix() ) || sIgnoreFiles.contains( info.fileName() ) || info.filePath().startsWith( "/" + sMetadataFolder );
 }
 
 bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &config )

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1699,10 +1699,7 @@ void MerginApi::pushStartReplyFinished()
 
       MerginFile file = files.first();
 
-      QTimer::singleShot( 10000, this, [this, projectFullName, transactionUUID, file]()
-      {
-        pushFile( projectFullName, transactionUUID, file );
-      } );
+      pushFile( projectFullName, transactionUUID, file );
       emit pushFilesStarted();
     }
     else  // pushing only files to be removed
@@ -1788,10 +1785,7 @@ void MerginApi::pushFileReplyFinished()
     int chunkNo = currentFile.chunks.indexOf( chunkID );
     if ( chunkNo < currentFile.chunks.size() - 1 )
     {
-      QTimer::singleShot( 10000, this, [this, projectFullName, transactionUUID, currentFile, chunkNo]()
-      {
-        pushFile( projectFullName, transactionUUID, currentFile, chunkNo + 1 );
-      } );
+      pushFile( projectFullName, transactionUUID, currentFile, chunkNo + 1 );
     }
     else
     {
@@ -1803,17 +1797,11 @@ void MerginApi::pushFileReplyFinished()
       if ( !transaction.pushQueue.isEmpty() )
       {
         MerginFile nextFile = transaction.pushQueue.first();
-        QTimer::singleShot( 10000, this, [this, projectFullName, transactionUUID, nextFile]()
-        {
-          pushFile( projectFullName, transactionUUID, nextFile );
-        } );
+        pushFile( projectFullName, transactionUUID, nextFile );
       }
       else
       {
-        QTimer::singleShot( 10000, this, [this, projectFullName, transactionUUID]()
-        {
-          pushFinish( projectFullName, transactionUUID );
-        } );
+        pushFinish( projectFullName, transactionUUID );
       }
     }
   }

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -335,6 +335,7 @@ class MerginApi: public QObject
     static const int MERGIN_API_VERSION_MAJOR = 2020;
     static const int MERGIN_API_VERSION_MINOR = 4;
     static const QString sMetadataFile;
+    static const QString sMetadataFolder;
     static const QString sMerginConfigFile;
     static const QString sDefaultApiRoot;
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -407,7 +407,7 @@ class MerginApi: public QObject
     QString apiRoot() const;
     void setApiRoot( const QString &apiRoot );
 
-    QString merginUserName() const; // TODO: replace (can be replaced with userInfo->username)
+    QString merginUserName() const;
 
     MerginApiStatus::VersionStatus apiVersionStatus() const;
     void setApiVersionStatus( const MerginApiStatus::VersionStatus &apiVersionStatus );
@@ -415,6 +415,7 @@ class MerginApi: public QObject
     //! Returns details about currently active transactions (both push and pull). Useful for tests
     Transactions transactions() const { return mTransactionalStatus; }
 
+    // Returns true for files that are under .mergin folder or contains ignored extension from sIgnoreExtensions
     static bool isInIgnore( const QFileInfo &info );
 
     /**


### PR DESCRIPTION
We had a broken sync on Windows because `QDirIterator` on Unix systems ignores the hidden folders, but lists them on  Windows (as the folder can start with a dot). It resulted in `.mergin` folder files being scheduled for synchronisation. They were assigned a chunk id, but Mergin correctly ignored these files. This led to 404s due to chunk IDs mismatch.

I fixed this by ignoring all files in `.mergin` folder in `MerginApi::isInIgnore`. It should not change anything on UNIX systems as this folder was never listed (always ignored).

Note, our Windows release is still just experimental, so it includes other bugs.