### PR TITLE
Editing fixes

### DIFF
--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -354,7 +354,6 @@ void RecordingMapTool::lookForVertex( const QPointF &clickedPoint, double search
   if ( idx >= 0 )
   {
     toggleSelectedVertexVisibility( idx );
-    //mActiveVertex = mVertices.at( idx );
 
     if ( mActiveVertex.type() == Vertex::Existing )
     {
@@ -651,6 +650,20 @@ void RecordingMapTool::setRecordPoint( QgsPoint newRecordPoint )
   emit recordPointChanged( mRecordPoint );
 }
 
+const Vertex &RecordingMapTool::activeVertex() const
+{
+  return mActiveVertex;
+}
+
+void RecordingMapTool::setActiveVertex( const Vertex &newActiveVertex )
+{
+  if ( mActiveVertex == newActiveVertex )
+    return;
+  mActiveVertex = newActiveVertex;
+  emit activeVertexChanged( mActiveVertex );
+}
+
+
 const QgsVertexId &Vertex::vertexId() const
 {
   return mVertexId;
@@ -661,7 +674,6 @@ void Vertex::setVertexId( const QgsVertexId &newVertexId )
   if ( mVertexId == newVertexId )
     return;
   mVertexId = newVertexId;
-//  emit vertexIdChanged(mVertexId);
 }
 
 QgsPoint Vertex::coordinates() const
@@ -674,7 +686,6 @@ void Vertex::setCoordinates( QgsPoint newCoordinates )
   if ( mCoordinates == newCoordinates )
     return;
   mCoordinates = newCoordinates;
-//  emit coordinatesChanged(mCoordinates);
 }
 
 const Vertex::VertexType &Vertex::type() const
@@ -687,25 +698,4 @@ void Vertex::setType( const VertexType &newType )
   if ( mType == newType )
     return;
   mType = newType;
-//  emit typeChanged(mType);
-}
-
-//void Vertex::set(const Vertex &other)
-//{
-//  setType( other.type() );
-//  setVertexId( other.vertexId() );
-//  setCoordinates( other.coordinates() );
-//}
-
-const Vertex &RecordingMapTool::activeVertex() const
-{
-  return mActiveVertex;
-}
-
-void RecordingMapTool::setActiveVertex( const Vertex &newActiveVertex )
-{
-  if ( mActiveVertex == newActiveVertex )
-    return;
-  mActiveVertex = newActiveVertex;
-  emit activeVertexChanged( mActiveVertex );
 }

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -326,7 +326,6 @@ void RecordingMapTool::lookForVertex( const QPointF &clickedPoint, double search
 {
   double minDistance = std::numeric_limits<double>::max();
   double currentDistance = 0;
-  QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings()->mapSettings() );
   double searchDistance = pixelsToMapUnits( searchRadius );
 
   QgsPoint pnt = mapSettings()->screenToCoordinate( clickedPoint );
@@ -494,7 +493,7 @@ void RecordingMapTool::toggleHandleVisibility()
 double RecordingMapTool::pixelsToMapUnits( double numPixels )
 {
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings()->mapSettings() );
-  return numPixels * context.scaleFactor() * context.mapToPixel().mapUnitsPerPixel();
+  return numPixels * InputUtils::calculateDpRatio() * context.scaleFactor() * context.mapToPixel().mapUnitsPerPixel();
 }
 
 Vertex::Vertex()

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -234,8 +234,11 @@ void RecordingMapTool::onPositionChanged()
 
 void RecordingMapTool::prepareEditing()
 {
-  setState( MapToolState::View );
-  setRecordedGeometry( mInitialGeometry );
+  if ( !mInitialGeometry.isEmpty() )
+  {
+    setState( MapToolState::View );
+    setRecordedGeometry( mInitialGeometry );
+  }
 }
 
 void RecordingMapTool::createNodesAndHandles()

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -231,9 +231,7 @@ class RecordingMapTool : public AbstractMapTool
 
   private:
     double pixelsToMapUnits( double numPixels );
-
-    void toggleSelectedVertexVisibility( int vertexIndex );
-    void toggleHandleVisibility();
+    //void toggleHandleVisibility();
 
     QgsGeometry mRecordedGeometry;
     QgsGeometry mInitialGeometry;

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -233,6 +233,7 @@ class RecordingMapTool : public AbstractMapTool
     double pixelsToMapUnits( double numPixels );
 
     void toggleSelectedVertexVisibility( int vertexIndex );
+    void toggleHandleVisibility();
 
     QgsGeometry mRecordedGeometry;
     QgsGeometry mInitialGeometry;
@@ -248,6 +249,7 @@ class RecordingMapTool : public AbstractMapTool
     QgsGeometry mExistingVertices;
     QgsGeometry mMidPoints;
     QgsGeometry mHandles;
+    QgsGeometry mHiddenHandle;
 
     MapToolState mState = MapToolState::Record;
 

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -135,9 +135,9 @@ class RecordingMapTool : public AbstractMapTool
     Q_INVOKABLE bool hasValidGeometry() const;
 
     /**
-     * Finds vertex id which matches given screen coordinates.
+     * Finds vertex id which matches given screen coordinates. Search radius defined in pixels
      */
-    Q_INVOKABLE void lookForVertex( const QPointF &clickedPoint, double searchRadius = 0.001 );
+    Q_INVOKABLE void lookForVertex( const QPointF &clickedPoint, double searchRadius = 5 );
 
     /**
      * Updates vertex at the active vertex position and updates recordedGeometry
@@ -236,6 +236,8 @@ class RecordingMapTool : public AbstractMapTool
      * start/end points and "handles" (for lines). Also fills nodes index.
      */
     void createNodesAndHandles();
+
+    double pixelsToMapUnits( double numPixels );
 
     QgsGeometry mRecordedGeometry;
     QgsGeometry mInitialGeometry;

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -225,19 +225,20 @@ class RecordingMapTool : public AbstractMapTool
 
   private slots:
     void prepareEditing();
-
-  protected:
-    //! Unifies Z coordinate of the point with current layer - drops / adds it
-    void fixZ( QgsPoint &point ) const;
-
-  private:
     /**
      * Creates geometries represeinting existing nodes, midpoints (for lines and polygons),
      * start/end points and "handles" (for lines). Also fills nodes index.
      */
     void createNodesAndHandles();
 
+  protected:
+    //! Unifies Z coordinate of the point with current layer - drops / adds it
+    void fixZ( QgsPoint &point ) const;
+
+  private:
     double pixelsToMapUnits( double numPixels );
+
+    void toggleSelectedVertexVisibility( int vertexIndex );
 
     QgsGeometry mRecordedGeometry;
     QgsGeometry mInitialGeometry;

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -231,7 +231,11 @@ class RecordingMapTool : public AbstractMapTool
 
   private:
     double pixelsToMapUnits( double numPixels );
-    //void toggleHandleVisibility();
+
+    /**
+     * Check whether given point should be used for creating markers/handles
+     */
+    bool shouldUseVertex( QgsPoint point );
 
     QgsGeometry mRecordedGeometry;
     QgsGeometry mInitialGeometry;

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -252,7 +252,7 @@ class RecordingMapTool : public AbstractMapTool
     QgsGeometry mMidPoints;
     QgsGeometry mHandles;
 
-    MapToolState mState = MapToolState::View;
+    MapToolState mState = MapToolState::Record;
 
     Vertex mActiveVertex;
     QVector< Vertex > mVertices;

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -56,8 +56,6 @@ class Vertex
     const VertexType &type() const;
     void setType( const VertexType &newType );
 
-//    void set( const Vertex &other );
-
     bool operator==( const Vertex &other )
     {
       return other.vertexId() == mVertexId && other.type() == mType;
@@ -145,6 +143,9 @@ class RecordingMapTool : public AbstractMapTool
      */
     Q_INVOKABLE void updateVertex( const QgsPoint &point );
 
+    /**
+     * Returns coordinates of the active vertex in map CRS
+     */
     Q_INVOKABLE QgsPoint vertexMapCoors( const Vertex &vertex ) const;
 
     Q_INVOKABLE void cancelGrab();
@@ -202,17 +203,10 @@ class RecordingMapTool : public AbstractMapTool
     void recordingTypeChanged( const RecordingMapTool::RecordingType &recordingType );
 
     void initialGeometryChanged( const QgsGeometry &initialGeometry );
-
     void existingVerticesChanged( const QgsGeometry &existingVertices );
-
     void midPointsChanged( const QgsGeometry &midPoints );
-
     void handlesChanged( const QgsGeometry &handles );
-
     void stateChanged( const RecordingMapTool::MapToolState &state );
-
-    void clickedVertexIdChanged( QgsVertexId id );
-    void clickedPointChanged( QgsPoint point );
 
     void crosshairPositionChanged( QPointF crosshairPosition );
 

--- a/app/qml/map/RecordingToolbar.qml
+++ b/app/qml/map/RecordingToolbar.qml
@@ -93,7 +93,7 @@ Item {
                 width: root.itemSize
                 text: qsTr("Remove")
                 imageSource: InputStyle.undoIcon
-                enabled: manualRecording || root.toolMode === RecordingMapTool.View
+                enabled: manualRecording && root.toolMode !== RecordingMapTool.View
 
                 onActivated: root.removePointClicked()
             }
@@ -109,7 +109,7 @@ Item {
                 width: root.itemSize
                 text: qsTr("Add")
                 imageSource: InputStyle.plusIcon
-                enabled: manualRecording || root.toolMode !== RecordingMapTool.View
+                enabled: manualRecording && root.toolMode !== RecordingMapTool.View
 
                 onActivated: root.addClicked()
             }

--- a/app/test/testmaptools.cpp
+++ b/app/test/testmaptools.cpp
@@ -420,12 +420,12 @@ void TestMapTools::testLookForVertex()
   // start point, should be invalid vertex as we are switching to the
   // recording state are reset selection
   QPointF screenPoint = ms->coordinateToScreen( QgsPoint( -0.05, -0.13 ) );
-  mapTool->lookForVertex( screenPoint, 0.05 );
+  mapTool->lookForVertex( screenPoint );
   QVERIFY( !mapTool->activeVertex().isValid() );
 
   // first point
   screenPoint = ms->coordinateToScreen( QgsPoint( -0.01, 0.1 ) );
-  mapTool->lookForVertex( screenPoint, 0.05 );
+  mapTool->lookForVertex( screenPoint );
   QVERIFY( mapTool->activeVertex().isValid() );
   QCOMPARE( mapTool->activeVertex().vertexId().part, 0 );
   QCOMPARE( mapTool->activeVertex().vertexId().ring, 0 );
@@ -433,7 +433,7 @@ void TestMapTools::testLookForVertex()
 
   // midpoint
   screenPoint = ms->coordinateToScreen( QgsPoint( 0.6, 1.2 ) );
-  mapTool->lookForVertex( screenPoint, 0.05 );
+  mapTool->lookForVertex( screenPoint );
   QVERIFY( mapTool->activeVertex().isValid() );
   QCOMPARE( mapTool->activeVertex().vertexId().part, 0 );
   QCOMPARE( mapTool->activeVertex().vertexId().ring, 0 );
@@ -441,6 +441,6 @@ void TestMapTools::testLookForVertex()
 
   // distant point. should return invalid vertex id
   screenPoint = ms->coordinateToScreen( QgsPoint( 3, 2 ) );
-  mapTool->lookForVertex( screenPoint, 0.05 );
+  mapTool->lookForVertex( screenPoint );
   QVERIFY( !mapTool->activeVertex().isValid() );
 }

--- a/app/test/testmaptools.cpp
+++ b/app/test/testmaptools.cpp
@@ -417,13 +417,11 @@ void TestMapTools::testLookForVertex()
   mapTool->setLayer( lineLayer );
   mapTool->setInitialGeometry( geometry );
 
-  // start point
+  // start point, should be invalid vertex as we are switching to the
+  // recording state are reset selection
   QPointF screenPoint = ms->coordinateToScreen( QgsPoint( -0.05, -0.13 ) );
   mapTool->lookForVertex( screenPoint, 0.05 );
-  QVERIFY( mapTool->activeVertex().isValid() );
-  QCOMPARE( mapTool->activeVertex().vertexId().part, 0 );
-  QCOMPARE( mapTool->activeVertex().vertexId().ring, 0 );
-  QCOMPARE( mapTool->activeVertex().vertexId().vertex, 0 );
+  QVERIFY( !mapTool->activeVertex().isValid() );
 
   // first point
   screenPoint = ms->coordinateToScreen( QgsPoint( -0.01, 0.1 ) );


### PR DESCRIPTION
More fixes and updates to the geometry editing:

- better threshold for selecting active vertex
- hide marker for active vertex
- hide handle and start/end marker if start/end point of the line is selected
- fix toolbar buttons availability depending on the current state
- show crosshair when new feature is recorded
- fix broken test
- remove unused code