### PR TITLE
Fix language selection for several languages

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -500,6 +500,48 @@ void InputUtils::quitApp()
   QCoreApplication::quit();
 }
 
+QLocale InputUtils::fixLocaleCountry( QLocale applocale )
+{
+  QLocale out = applocale;
+
+  if ( applocale.language() == QLocale::English )
+  {
+    out = QLocale( QLocale::English, QLocale::AnyCountry );
+  }
+  else if ( applocale.language() == QLocale::German || applocale.language() == QLocale::LowGerman || applocale.language() == QLocale::SwissGerman )
+  {
+    out = QLocale( QLocale::German, QLocale::AnyCountry );
+  }
+  else if ( applocale.language() == QLocale::French )
+  {
+    out = QLocale( QLocale::French, QLocale::AnyCountry );
+  }
+  else if ( applocale.language() == QLocale::Italian )
+  {
+    out = QLocale( QLocale::Italian, QLocale::AnyCountry );
+  }
+  else if ( applocale.language() == QLocale::Turkish )
+  {
+    out = QLocale( QLocale::Turkish, QLocale::AnyCountry );
+  }
+  else if ( applocale.language() == QLocale::Polish )
+  {
+    out = QLocale( QLocale::Polish, QLocale::AnyCountry );
+  }
+  else if ( applocale.language() == QLocale::Slovak )
+  {
+    out = QLocale( QLocale::Slovak, QLocale::AnyCountry );
+  }
+  else if ( applocale.language() == QLocale::Croatian )
+  {
+    out = QLocale( QLocale::Croatian, QLocale::AnyCountry );
+  }
+
+  CoreUtils::log( QStringLiteral( "Locale" ), QStringLiteral( "Converting %1 locale to simple %2" ).arg( applocale.name(), out.name() ) );
+
+  return out;
+}
+
 QString InputUtils::appPlatform()
 {
 #if defined( ANDROID )

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -520,6 +520,10 @@ QLocale InputUtils::fixLocaleCountry( QLocale applocale )
   {
     out = QLocale( QLocale::Italian, QLocale::AnyCountry );
   }
+  else if ( applocale.language() == QLocale::Spanish )
+  {
+    out = QLocale( QLocale::Spanish, QLocale::AnyCountry );
+  }
   else if ( applocale.language() == QLocale::Turkish )
   {
     out = QLocale( QLocale::Turkish, QLocale::AnyCountry );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -137,6 +137,9 @@ class InputUtils: public QObject
 
     Q_INVOKABLE void quitApp();
 
+    // Removes country code from locale and replaces it with AnyCountry
+    static QLocale fixLocaleCountry( QLocale applocale );
+
     /**
      * Method copies all entries from given source path to destination path. If cannot copy a file for the first time,
      * removes it and tries again (overwrite a file). If failes again, skips the file, sets result to false and continue.

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -353,19 +353,6 @@ int main( int argc, char *argv[] )
   QCoreApplication::setApplicationName( "Input" ); // used by QSettings
   QCoreApplication::setApplicationVersion( version );
 
-  // Initialize translations
-  QLocale locale;
-  QTranslator inputTranslator;
-  if ( inputTranslator.load( locale, "input", "_", ":/" ) )
-  {
-    app.installTranslator( &inputTranslator );
-    qDebug() <<  "Loaded input translation for " << locale;
-  }
-  else
-  {
-    qDebug() <<  "Error in loading input translation for " << locale;
-  }
-
 #ifdef INPUT_TEST
   InputTests tests;
   tests.parseArgs( argc, argv );
@@ -391,6 +378,35 @@ int main( int argc, char *argv[] )
 
   CoreUtils::setLogFilename( projectDir + "/.logs" );
   setEnvironmentQgisPrefixPath();
+
+  // Initialize translations
+  QLocale locale;
+
+  /*
+   * We need to fix locale country code (capital letters after underscore)
+   * in system locale, because QT tries to do exact match, for example:
+   * system locale "en_GB" -> our provided locale "en" would not match and
+   * QT would try to find translation for other system language.
+   *
+   * If it fails it goes through the same process again, but without country code.
+   * We want to match "en_GB" with "en" immediately, thus we remove the country code.
+   *
+   * This fix can be removed from QT 5.15
+   * See: https://github.com/MerginMaps/input/issues/1417
+   * See: QTBUG-86179
+   */
+  locale = InputUtils::fixLocaleCountry( locale );
+
+  QTranslator inputTranslator;
+  if ( inputTranslator.load( locale, "input", "_", ":/" ) )
+  {
+    app.installTranslator( &inputTranslator );
+    qDebug() <<  "Loaded input translation" << app.locale() << "for" << locale;
+  }
+  else
+  {
+    qDebug() <<  "Error in loading input translation for " << locale;
+  }
 
   QString appBundleDir;
   QString demoDir;

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -10,6 +10,7 @@
 #include "testutilsfunctions.h"
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QLocale>
 
 #include "qgsapplication.h"
 #include "qgscoordinatereferencesystem.h"
@@ -725,5 +726,33 @@ void TestUtilsFunctions::testGeometryIcons()
   for ( const auto &test : testcases_features )
   {
     QCOMPARE( mUtils->loadIconFromFeature( test.first ), test.second );
+  }
+}
+
+void TestUtilsFunctions::testFixCountryCode()
+{
+  QVector< QPair< QLocale, QLocale > > testcases =
+  {
+    { QLocale( QLocale::English, QLocale::Canada ), QLocale( QLocale::English, QLocale::AnyCountry ) },
+    { QLocale( QLocale::English, QLocale::UnitedStates ), QLocale( QLocale::English, QLocale::AnyCountry ) },
+    { QLocale( QLocale::English, QLocale::UnitedKingdom ), QLocale( QLocale::English, QLocale::AnyCountry ) },
+    { QLocale( QLocale::English, QLocale::Australia ), QLocale( QLocale::English, QLocale::AnyCountry ) },
+    { QLocale( QLocale::English, QLocale::NewZealand ), QLocale( QLocale::English, QLocale::AnyCountry ) },
+
+    { QLocale( QLocale::French, QLocale::Canada ), QLocale( QLocale::French, QLocale::AnyCountry ) },
+    { QLocale( QLocale::French, QLocale::France ), QLocale( QLocale::French, QLocale::AnyCountry ) },
+    { QLocale( QLocale::French, QLocale::Belgium ), QLocale( QLocale::French, QLocale::AnyCountry ) },
+
+    { QLocale( QLocale::Spanish, QLocale::Spain ), QLocale( QLocale::Spanish, QLocale::AnyCountry ) },
+    { QLocale( QLocale::Spanish, QLocale::Mexico ), QLocale( QLocale::Spanish, QLocale::AnyCountry ) },
+
+    { QLocale( QLocale::Slovak, QLocale::Slovakia ), QLocale( QLocale::Slovak, QLocale::AnyCountry ) },
+
+    { QLocale( QLocale::Polish, QLocale::Poland ), QLocale( QLocale::Polish, QLocale::AnyCountry ) }
+  };
+
+  for ( const auto &test : testcases )
+  {
+    QCOMPARE( mUtils->fixLocaleCountry( test.first ), test.second );
   }
 }

--- a/app/test/testutilsfunctions.h
+++ b/app/test/testutilsfunctions.h
@@ -43,6 +43,7 @@ class TestUtilsFunctions: public QObject
     void testMapPointToGps();
     void testEquals();
     void testGeometryIcons();
+    void testFixCountryCode();
 
   private:
     void testFormatDuration( const QDateTime &t0, qint64 diffSecs, const QString &expectedResult );


### PR DESCRIPTION
This issue is well described here: https://github.com/MerginMaps/input/issues/1417#issuecomment-863382773 

QT tries to exactly match systems' locale with a translation file we provide. This is a problem for codes like `en_US`, `fr_CA`, where we only provide file with name `en` or `fr`. These translation files would never be picked, despite being translated. To fight this issue QT has a following system: https://doc.qt.io/archives/qt-5.14/qtranslator.html#load-1 (TL;DR - if it can not exactly match any system language, it tries to cut out the country code and match only language codes). 

---

Imagine situation like this:
  - Your system languages
    1. `en_US`
    2. `kr_KR`

 - Input provides these translation files:
   - `en`
   - `kr_KR`

 - QT tries to match it in two rounds:
   1. exact match:
       - `en_US` exactly compared with `en` (FAIL)
       - `kr_KR` exactly compared with `kr_KR` (SUCCESS, STOP)

`kr_KR` would be thus picked as app language, despite we also provided translation for english.

---

This issue is _fixed_ by removing country codes from locales for some languages (english, german, french, spanish,..). The PR, therefore, fixes these languages:
 - English
 - French
 - Spanish
 - German
 - Slovak
 - Polish
 - Croatian
 - Turkish
 - Italian

Upgrade to new QT version would fix this properly; we can remove the added code then.

Fixes (partially, for some languages) #1417 
Related #743

CU-2a6zn2p

@PeterPetrik do we also want to have the language selection page?
