### PR TITLE
Reduce Huawei crash rate on back button

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -2,9 +2,14 @@ package uk.co.lutraconsulting;
 import android.os.Bundle;
 import android.view.WindowManager;
 import org.qtproject.qt5.android.bindings.QtActivity;
+import android.util.Log;
+import android.os.Build;
+import java.lang.Exception;
 
 public class InputActivity extends QtActivity
 {
+  private static final String TAG = "Mergin Maps Input Activity";
+
   @Override
   public void onCreate(Bundle savedInstanceState)
   {
@@ -14,6 +19,41 @@ public class InputActivity extends QtActivity
     // go into sleep and recording is not interrupted
     getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
   }
+
+  public void quitGracefully()
+  {
+    String man = android.os.Build.MANUFACTURER.toUpperCase();
+
+    Log.d( TAG, String.format("quitGracefully() from Java, MANUFACTURER: '%s'", man ) );
+    
+    //
+    // QT app exit on back button causes crashes on some manufacturers (mainly Huawei, but also Samsung Galaxy recently).
+    //
+    // Let's play safe and only use this fix for HUAWEI phones for now.
+    // If the fix proves itself in next release, we can add it for all other manufacturers.
+    //
+    // Qt bug: QTBUG-82617
+    // See: https://developernote.com/2022/03/crash-at-std-thread-and-std-mutex-destructors-on-android/#comment-694101
+    // See: https://stackoverflow.com/questions/61321845/qt-app-crashes-at-the-destructor-of-stdthread-on-android-10-devices
+    //
+
+    boolean shouldQuit = man.contains( "HUAWEI" );
+
+    if ( shouldQuit )
+    {
+      try
+      {
+        finishAffinity();
+        System.exit(0);
+      }
+      catch ( Exception exp )
+      {
+        exp.printStackTrace();
+        Log.d( TAG, String.format( "quitGracefully() failed to execute: '%s'", exp.toString() ) );
+      }
+    }
+  }
+
   @Override
   protected void onDestroy()
   {

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -309,6 +309,16 @@ bool AndroidUtils::isBluetoothTurnedOn()
 #endif
 }
 
+void AndroidUtils::quitApp()
+{
+#ifdef ANDROID
+  QtAndroid::androidActivity().callMethod<void>( "quitGracefully", "()V" );
+
+  // If quitGracefully failed or this device is not of specified manufacturer, let's exit via QT
+  QCoreApplication::quit();
+#endif
+}
+
 bool AndroidUtils::requestStoragePermission()
 {
 #ifdef ANDROID

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -59,6 +59,8 @@ class AndroidUtils: public QObject
     void turnBluetoothOn();
     bool isBluetoothTurnedOn();
 
+    static void quitApp();
+
     /**
       * Starts ACTION_PICK activity which opens a gallery. If an image is selected,
       * handler of the activity emits imageSelected signal.

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -497,7 +497,14 @@ void InputUtils::turnBluetoothOn()
 
 void InputUtils::quitApp()
 {
-  QCoreApplication::quit();
+  if ( appPlatform() == QStringLiteral( "android" ) )
+  {
+    AndroidUtils::quitApp();
+  }
+  else
+  {
+    QCoreApplication::quit();
+  }
 }
 
 QString InputUtils::appPlatform()

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -110,9 +110,19 @@ ApplicationWindow {
       }
       else projectPanel.openPanel()
 
-        // get focus when any project is active, otherwise let focus to merginprojectpanel
-        if ( __appSettings.activeProject )
-          mainPanel.forceActiveFocus()
+      // get focus when any project is active, otherwise let focus to merginprojectpanel
+      if ( __appSettings.activeProject )
+        mainPanel.forceActiveFocus()
+
+
+      // Catch back button click (if no other component catched it so far)
+      // to prevent QT from quitting the APP immediately
+      contentItem.Keys.released.connect( function( event ) {
+        if ( event.key === Qt.Key_Back ) {
+          event.accepted = true
+          window.backButtonPressed()
+        }
+      } )
 
         console.log("Application initialized!")
     }
@@ -605,5 +615,24 @@ ApplicationWindow {
 
       z: 1000 // unfortunatelly we need this hack because some parts of application still sets z coord
       anchors.fill: parent
+    }
+
+    Timer {
+      id: closeAppTimer
+
+      interval: 3000
+      running: false
+      repeat: false
+    }
+
+    function backButtonPressed() {
+
+      if ( closeAppTimer.running ) {
+        __inputUtils.quitApp()
+      }
+      else {
+        closeAppTimer.start()
+        showMessage( qsTr( "Press back again to quit the app" ) )
+      }
     }
 }


### PR DESCRIPTION
This is an effort to reduce the number of crashes happening on Huawei devices when exiting the app with back button.
There are two fixes:
 - First: we do not close the app immediately after the back button is tapped; instead, we show toast saying "hit the back button again to close the app". This way we reduce the number of accidental hits of the back button.
 - Second: instead of letting QT quit the app, we now call Java to exit the app. This is due to some blogs/stackoverflow's that tried to find a workaround to this issue. See: https://developernote.com/2022/03/crash-at-std-thread-and-std-mutex-destructors-on-android/#comment-694101 and https://stackoverflow.com/questions/61321845/qt-app-crashes-at-the-destructor-of-stdthread-on-android-10-devices

So far the second fix is applied only to Huawei devices. If it will behave well, we can apply it to all manufacturers (Recently there are crashes on other devices too).

QT has not yet provided a fix to this issue (see https://bugreports.qt.io/browse/QTBUG-82617)

Fixes ( partially ) #1060 