### PR TITLE
More fixed for geometry editing

### DIFF
--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -425,9 +425,13 @@ void RecordingMapTool::createNodesAndHandles()
     if ( mRecordedGeometry.type() != QgsWkbTypes::PointGeometry && vertexId.vertex < geom->vertexCount( vertexId.part, vertexId.ring ) - 1 )
     {
       QgsVertexId id( vertexId.part, vertexId.ring, vertexId.vertex + 1 );
-      QgsPoint midPoint = QgsGeometryUtils::midpoint( geom->vertexAt( vertexId ), geom->vertexAt( id ) );
-      midPoints->addGeometry( midPoint.clone() );
-      mVertices.push_back( Vertex( id, midPoint, Vertex::MidPoint ) );
+      // hide midpoints on the left and right side of the selected node
+      if ( shouldUseVertex( geom->vertexAt( vertexId ) ) && shouldUseVertex( geom->vertexAt( id ) ) )
+      {
+        QgsPoint midPoint = QgsGeometryUtils::midpoint( geom->vertexAt( vertexId ), geom->vertexAt( id ) );
+        midPoints->addGeometry( midPoint.clone() );
+        mVertices.push_back( Vertex( id, midPoint, Vertex::MidPoint ) );
+      }
     }
 
     //

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -428,7 +428,7 @@ void RecordingMapTool::createNodesAndHandles()
           QgsVertexId startId( vertexId.part, vertexId.ring, 0 );
           QgsVertexId endId( vertexId.part, vertexId.ring, 1 );
 
-          QgsPoint handlePoint = QgsGeometryUtils::interpolatePointOnLine( geom->vertexAt( startId ), geom->vertexAt( endId ), -1 );
+          QgsPoint handlePoint = QgsGeometryUtils::interpolatePointOnLine( geom->vertexAt( startId ), geom->vertexAt( endId ), -0.5 );
 
           if ( shouldUseVertex( geom->vertexAt( startId ) ) && shouldUseVertex( handlePoint ) )
           {
@@ -446,7 +446,7 @@ void RecordingMapTool::createNodesAndHandles()
           QgsVertexId startId( vertexId.part, vertexId.ring, vertexCount - 2 );
           QgsVertexId endId( vertexId.part, vertexId.ring, vertexCount - 1 );
 
-          QgsPoint handlePoint = QgsGeometryUtils::interpolatePointOnLine( geom->vertexAt( startId ), geom->vertexAt( endId ), 1 );
+          QgsPoint handlePoint = QgsGeometryUtils::interpolatePointOnLine( geom->vertexAt( startId ), geom->vertexAt( endId ), 1.5 );
 
           if ( shouldUseVertex( geom->vertexAt( endId ) ) && shouldUseVertex( handlePoint ) )
           {

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -145,7 +145,7 @@ class RecordingMapTool : public AbstractMapTool
     /**
      * Finds vertex id which matches given screen coordinates. Search radius defined in pixels
      */
-    Q_INVOKABLE void lookForVertex( const QPointF &clickedPoint, double searchRadius = 5 );
+    Q_INVOKABLE void lookForVertex( const QPointF &clickedPoint, double searchRadius = 3 );
 
     /**
      * Updates vertex at the active vertex position and updates recordedGeometry

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -237,6 +237,11 @@ class RecordingMapTool : public AbstractMapTool
      */
     void createNodesAndHandles();
 
+    /**
+     * Grabs next vertex after the removal of the currently selected vertex
+     */
+    void grabNextVertex( const int removedVertexId );
+
   protected:
     //! Unifies Z coordinate of the point with current layer - drops / adds it
     void fixZ( QgsPoint &point ) const;


### PR DESCRIPTION
A few more fixes in the geometry editing:

- lower threshold for vertex lookup;
- hide midpoint markes on the left/right sides of the active vertex;
- hopefully fixed issue with vertex removal.