### PR TITLE
add jump animation when selecting vertex

### DIFF
--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -86,7 +86,7 @@ Item {
 
         if ( !isNaN( newCenter.x ) && !isNaN( newCenter.y ) )
         {
-          root.map.mapSettings.setCenter( newCenter )
+          root.map.jump( crosshair.screenPoint, root.map.mapSettings.coordinateToScreen( newCenter ) )
         }
       }
     }

--- a/qgsquick/plugin/qgsquickmapcanvas.qml
+++ b/qgsquick/plugin/qgsquickmapcanvas.qml
@@ -55,9 +55,6 @@ Item {
   //! This signal is emitted independently of double tap / click
   signal clicked(var point)
 
-  //! This signal is only emitted if there is no double tap/click coming after a short delay
-//  signal confirmedClicked(var point) // TODO: ideally get rid of this one
-
   //! Signal emitted when user holds pointer on map
   signal longPressed(var point)
 
@@ -103,6 +100,32 @@ Item {
     mapCanvasWrapper.refresh()
   }
 
+  /**
+   * Animates movement of map canvas from oldPos to newPos.
+   *
+   * oldPos and newPos need to be in device pixels.
+   */
+  function jump( oldPos, newPos )
+  {
+    freeze('jump')
+
+    let newPosMapCRS = mapCanvasWrapper.mapSettings.screenToCoordinate( newPos )
+    let oldPosMapCRS = mapCanvasWrapper.mapSettings.screenToCoordinate( oldPos )
+
+    // Disable animation until initial position is set
+    jumpAnimator.enabled = false
+
+    jumpAnimator.px = oldPosMapCRS.x
+    jumpAnimator.py = oldPosMapCRS.y
+
+    jumpAnimator.enabled = true
+
+    jumpAnimator.px = newPosMapCRS.x
+    jumpAnimator.py = newPosMapCRS.y
+
+    unfreeze('jump')
+  }
+
   QgsQuick.MapCanvasMap {
     id: mapCanvasWrapper
 
@@ -112,6 +135,32 @@ Item {
     property var __freezecount: ({})
 
     freeze: false
+  }
+
+  Item {
+    id: jumpAnimator
+
+    property double px: 0
+    property double py: 0
+
+    Behavior on py {
+      SmoothedAnimation {
+        duration: 200
+        reversingMode: SmoothedAnimation.Immediate
+      }
+      enabled: jumpAnimator.enabled
+    }
+
+    Behavior on px {
+      SmoothedAnimation {
+        duration: 200
+        reversingMode: SmoothedAnimation.Immediate
+      }
+      enabled: jumpAnimator.enabled
+    }
+
+    onPxChanged: mapCanvasWrapper.mapSettings.setCenter( mapCanvasWrapper.mapSettings.toQgsPoint( Qt.point( px, py ) ) )
+    onPyChanged: mapCanvasWrapper.mapSettings.setCenter( mapCanvasWrapper.mapSettings.toQgsPoint( Qt.point( px, py ) ) )
   }
 
   // Mouse, stylus and other pointer devices handler

--- a/qgsquick/qgsquickmapsettings.cpp
+++ b/qgsquick/qgsquickmapsettings.cpp
@@ -297,3 +297,8 @@ void QgsQuickMapSettings::setDevicePixelRatio( const qreal &devicePixelRatio )
   mDevicePixelRatio = devicePixelRatio;
   emit devicePixelRatioChanged();
 }
+
+QgsPoint QgsQuickMapSettings::toQgsPoint( const QPointF &point )
+{
+  return QgsPoint( point );
+}

--- a/qgsquick/qgsquickmapsettings.h
+++ b/qgsquick/qgsquickmapsettings.h
@@ -249,6 +249,12 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
      */
     void setDevicePixelRatio( const qreal &devicePixelRatio );
 
+    /**
+     * Helper function to convert QPointF to QgsPoint without any transformations.
+     * Useful for converting these values in QML.
+     */
+    Q_INVOKABLE static QgsPoint toQgsPoint( const QPointF &point );
+
   signals:
     //! \copydoc QgsQuickMapSettings::project
     void projectChanged();


### PR DESCRIPTION
Adds "jump" animation to map canvas. It animates a movement between two positions.

This is an initial implementation of animations in QgsQuick, we might want to better incorporate this into cpp map canvas when adding more animations.

https://user-images.githubusercontent.com/22449698/182368517-e3937610-336c-473a-912a-7c51fed33d24.mp4


