### PR TITLE
Unify build version numbers on mobile platforms

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -229,19 +229,16 @@ jobs:
       - name: Calculate version code
         if: ${{ env.GIT_BRANCH }} == "master"
         env:
-          COMMIT_OFFSET: 1639 # number of commits since beginning. We use this number as offset to start counting from one
-          VERSIONS_MIN: 101005 # max VERSION_CODE number we had when we used version name in code. We iterate from this number by a number of commits
+          START_VERSION_OFFSET: 110000 # offset for build version number - due to previous builds
         run: |
             cd input-history
 
-            NUM_OF_COMMITS=`git rev-list --count HEAD`
-            echo "Number of commits: $NUM_OF_COMMITS, with offset: $((NUM_OF_COMMITS - ${{ env.COMMIT_OFFSET }}))"
-
-            NUM_OF_COMMITS_WITH_OFFSET=$((NUM_OF_COMMITS - ${{ env.COMMIT_OFFSET }}))
-            VERSION_CODE=$((VERSIONS_MIN + NUM_OF_COMMITS_WITH_OFFSET))
+            NUM_OF_COMMITS=`git rev-list --count --all`
+            
+            VERSION_CODE=$((START_VERSION_OFFSET + NUM_OF_COMMITS))
 
             echo "CI_VERSION_CODE=${VERSION_CODE}" >> $GITHUB_ENV
-            echo "CALCULATED VERSION CODE: ${VERSION_CODE}"
+            echo "Building version: ${VERSION_CODE}"
 
       - name: Build AAB
         if: ${{ env.GIT_BRANCH }} == "master"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -180,26 +180,32 @@ jobs:
             exit 1
           fi
 
-      # Parse Input-SDK version run number - it is used as middle integer in version number in CF_BUNDLE_VERSION
-      - name: Parse SDK version run number
-        uses: rishabhgupta/split-by@v1
-        id: split
+      - name: Download repo history
+        uses: actions/checkout@v2
         with:
-          string: ${{ env.INPUT_SDK_VERSION }}
-          split-by: '-'
+          path: input-history
+          fetch-depth: 0 # fetch all history
 
       - name: Create build system with qmake
         env:
-          VERSIONS_MIN: 2 # min version to start CF_BUNDLE_VERSION with, as previously we differentiated the number based on branch name
+          START_VERSION_OFFSET: 110000 # offset for build version number - due to previous builds
         run: |
           INPUT_DIR=`pwd`
 
+          # calculate CF_BUNDLE_VERSION
+          cd input-history
+          NUM_OF_COMMITS=`git rev-list --count --all`
+          cd ..
+
+          VERSION_CODE=$((START_VERSION_OFFSET + NUM_OF_COMMITS))
+          TIMESTAMP=`date "+%y.%m"`
+
+          CF_BUNDLE_VERSION=${TIMESTAMP}.${VERSION_CODE}
+
           # patch the Info.plist
           CF_BUNDLE_SHORT_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $INPUT_DIR/app/ios/Info.plist`
-          TIMESTAMP=`date "+%y%m%d%H%M%S"`
-          CF_BUNDLE_VERSION=${VERSIONS_MIN}.${{ steps.split.outputs._2 }}.${TIMESTAMP}
 
-          echo "Building version: $CF_BUNDLE_VERSION"
+          echo "Building version: $CF_BUNDLE_SHORT_VERSION ($CF_BUNDLE_VERSION)"
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_BUNDLE_VERSION" "$INPUT_DIR/app/ios/Info.plist"
 
           mkdir -p build-INPUT


### PR DESCRIPTION
PR unifies build versions between iOS and Android **(not app versions!)**

Previous iOS build version schema: 2(constant).XY(input-sdk version).TIMESTAMP
New iOS schema: YY.MM.number of commit with offset

New Android schema: number of commit with offset

> Note: Android supports only one number, while iOS build code can be in form X.Y.Z

New versions have a common Z, f.e.:
 - Android build version: `112620`
 - iOS build version: `22.08.112620`

Having SDK version in the build version was not an ideal solution. If someone updated SDK version in one branch, CI jobs in all other branches were failing then because their build versions were always smaller.