### PR TITLE
Add Info.plist check step to translations CI

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -64,3 +64,12 @@ jobs:
             echo "Run ./scripts/release_i18n_qm.bash to fix"
             exit 1
           fi
+
+      - name: Info.plist translations check
+        run: |
+          ./scripts/check_ios_translations.py ./app/ios/Info.plist ./app/i18n/input_i18n.qrc
+
+          if [ $? -gt "0" ]; then
+            echo "Info.plist does not include the same translations as input_i18n.qrc, exit.."
+            exit 1
+          fi


### PR DESCRIPTION
Translations CI now also automatically checks if `Info.plist` file includes all files listed in `input_i18n.qrc`