### PR TITLE
Edit buffer support (pt 3) 

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1852,7 +1852,10 @@ QgsGeometry InputUtils::createGeometryForLayer( QgsVectorLayer *layer )
 
     case QgsWkbTypes::MultiPolygon:
     {
+      QgsLineString *line = new QgsLineString();
+      QgsPolygon *polygon = new QgsPolygon( line );
       QgsMultiPolygon *multiPolygon = new QgsMultiPolygon();
+      multiPolygon->addGeometry( polygon );
       geometry.set( multiPolygon );
       break;
     }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1699,10 +1699,31 @@ FeatureLayerPair InputUtils::createFeatureLayerPair( QgsVectorLayer *layer, cons
   return FeatureLayerPair( feat, layer );
 }
 
+void InputUtils::createEditBuffer( QgsVectorLayer *layer )
+{
+  if ( layer )
+  {
+    if ( !layer->editBuffer() )
+    {
+      layer->startEditing();
+    }
+  }
+}
+
 FeatureLayerPair InputUtils::changeFeaturePairGeometry( FeatureLayerPair featurePair, const QgsGeometry &geometry )
 {
-  featurePair.featureRef().setGeometry( geometry );
-  return featurePair;
+  QgsVectorLayer *vlayer = featurePair.layer();
+  if ( vlayer )
+  {
+    InputUtils::createEditBuffer( vlayer );
+    QgsGeometry g( geometry );
+    vlayer->changeGeometry( featurePair.feature().id(), g );
+    vlayer->triggerRepaint();
+  }
+
+  QgsFeature f = featurePair.layer()->getFeature( featurePair.feature().id() );
+
+  return FeatureLayerPair( f, featurePair.layer() );
 }
 
 QgsPointXY InputUtils::extractPointFromFeature( const FeatureLayerPair &feature )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -462,8 +462,13 @@ class InputUtils: public QObject
     //! Creates featureLayerPair from geometry and layer, evaluates its expressions and returns it.
     Q_INVOKABLE static FeatureLayerPair createFeatureLayerPair( QgsVectorLayer *layer, const QgsGeometry &geometry, VariablesManager *variablesmanager );
 
-    //! Changes featureLayerPair's geometry to passed geometry
-    //! Geometry must be in the same CRS as the layer
+    Q_INVOKABLE static void createEditBuffer( QgsVectorLayer *layer );
+
+    /**
+     *  Changes featureLayerPair's geometry to passed geometry
+     *  Geometry must be in the same CRS as the layer
+     *  Change is written directly inside the layer edit buffer, but the buffer is not commited!
+     */
     Q_INVOKABLE static FeatureLayerPair changeFeaturePairGeometry( FeatureLayerPair featurePair, const QgsGeometry &geometry );
 
     // Calculates real screen DPR based on DPI

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -963,6 +963,17 @@ void RecordingMapTool::releaseVertex( const QgsPoint &point )
   setActiveVertex( Vertex() );
 }
 
+FeatureLayerPair RecordingMapTool::commitChanges()
+{
+  // TODO
+  return FeatureLayerPair();
+}
+
+void RecordingMapTool::rollbackChanges()
+{
+  // TODO
+}
+
 void RecordingMapTool::updateVertex( const Vertex &vertex, const QgsPoint &point )
 {
   if ( !mActiveLayer )

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -391,7 +391,22 @@ bool RecordingMapTool::hasValidGeometry() const
   {
     if ( mActiveLayer->geometryType() == QgsWkbTypes::PointGeometry )
     {
-      return mRecordedGeometry.constGet()->nCoordinates() == 1;
+      if ( mRecordedGeometry.isMultipart() )
+      {
+        const QgsAbstractGeometry *geom = mRecordedGeometry.constGet();
+        for ( auto it = geom->const_parts_begin(); it != geom->const_parts_end(); ++it )
+        {
+          if ( ( *it )->nCoordinates() != 1 )
+          {
+            return false;
+          }
+        }
+        return true;
+      }
+      else
+      {
+        return mRecordedGeometry.constGet()->nCoordinates() == 1;
+      }
     }
     else if ( mActiveLayer->geometryType() == QgsWkbTypes::LineGeometry )
     {

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -726,7 +726,7 @@ void RecordingMapTool::updateVisibleItems()
       // for polygons show midpoint if previous or next vertex is not active
       if ( mRecordedGeometry.type() == QgsWkbTypes::PolygonGeometry )
       {
-        if ( i > 0 && i < mVertices.count() - 1 )
+        if ( i > 0 && i < mVertices.count() )
         {
           Vertex prevVertex = mVertices.at( i - 1 );
 

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -698,11 +698,9 @@ void RecordingMapTool::updateVisibleItems()
   }
 
   Vertex v;
-  qDebug() << "COUNT" << mVertices.count();
   for ( int i = 0; i < mVertices.count(); i++ )
   {
     v = mVertices.at( i );
-    qDebug() << i << v.type() << v.coordinates().asWkt(8);
 
     if ( v.type() == Vertex::Existing && v != mActiveVertex )
     {
@@ -728,10 +726,9 @@ void RecordingMapTool::updateVisibleItems()
       // for polygons show midpoint if previous or next vertex is not active
       if ( mRecordedGeometry.type() == QgsWkbTypes::PolygonGeometry )
       {
-        if ( i > 0 && i < mVertices.count() )
+        if ( i > 0 && i <= mVertices.count() - 1 )
         {
           Vertex prevVertex = mVertices.at( i - 1 );
-          qDebug() << "PREV" << i - 1 << prevVertex.type() << prevVertex.coordinates().asWkt(8);
 
           // next vertex should be the either the next vertex in the sequence
           // if this midpoint is a first or middle midpoint of the ring or
@@ -740,7 +737,6 @@ void RecordingMapTool::updateVisibleItems()
           Vertex nextVertex = mVertices.at( i + 1 );
           if ( nextVertex.vertexId().part != v.vertexId().part || nextVertex.vertexId().ring != v.vertexId().ring )
           {
-            qDebug() << "FIND FIRST";
             for ( int j = 0 ; j < mVertices.count(); j++ )
             {
               nextVertex = mVertices.at( j );
@@ -750,7 +746,6 @@ void RecordingMapTool::updateVisibleItems()
               }
             }
           }
-          qDebug() << "NEXT" << i - 1 << nextVertex.type() << nextVertex.coordinates().asWkt(8);
 
           if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
           {

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -526,7 +526,17 @@ void RecordingMapTool::prepareEditing()
   {
     mActiveLayer->startEditing();
 
-    setState( MapToolState::View );
+    // if we are editing point layer we start with the grabbed point
+    if ( mActiveFeature.geometry().type() == QgsWkbTypes::PointGeometry && !mActiveFeature.geometry().isMultipart() )
+    {
+      Vertex v( QgsVertexId( 0, 0, 0 ), QgsPoint( mActiveFeature.geometry().asPoint() ), Vertex::Existing );
+      setActiveVertex( v );
+      setState( MapToolState::Grab );
+    }
+    else
+    {
+      setState( MapToolState::View );
+    }
     setRecordedGeometry( mActiveFeature.geometry() );
   }
   else if ( !mActiveFeature.isValid() || mActiveFeature.geometry().isEmpty() )

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -704,15 +704,32 @@ void RecordingMapTool::updateVisibleItems()
         }
       }
 
+      // for polygons show midpoint if previous or next vertex is not active
       if ( mRecordedGeometry.type() == QgsWkbTypes::PolygonGeometry )
       {
-        if ( mRecordedGeometry.isMultipart() )
+        Vertex prevVertex = mVertices.at( i - 1 );
+
+        // next vertex should be the either the next vertex in the sequence
+        // if this midpoint is a first or middle midpoint of the ring or
+        // it should be the first vertex of the correspoding ring is this
+        // midpoint is the last midpoint of the ring
+        Vertex nextVertex = mVertices.at( i + 1 );
+        if ( nextVertex.vertexId().part != v.vertexId().part || nextVertex.vertexId().ring != v.vertexId().ring )
         {
+          for ( int j = 0 ; j < mVertices.count(); j++ )
+          {
+            nextVertex = mVertices.at( j );
+            if ( nextVertex.vertexId().part == v.vertexId().part && nextVertex.vertexId().ring == v.vertexId().ring )
+            {
+              break;
+            }
+          }
         }
-        else
+
+        if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
         {
+          midPoints->addGeometry( v.coordinates().clone() );
         }
-        midPoints->addGeometry( v.coordinates().clone() );
       }
 
     }

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -712,42 +712,47 @@ void RecordingMapTool::updateVisibleItems()
       // for lines show midpoint if previous or next vertex is not active
       if ( mRecordedGeometry.type() == QgsWkbTypes::LineGeometry )
       {
-        Vertex prevVertex = mVertices.at( i - 1 );
-        Vertex nextVertex = mVertices.at( i + 1 );
-        if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
+        if ( i > 0 && i < mVertices.count() - 1 )
         {
-          midPoints->addGeometry( v.coordinates().clone() );
+          Vertex prevVertex = mVertices.at( i - 1 );
+          Vertex nextVertex = mVertices.at( i + 1 );
+          if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
+          {
+            midPoints->addGeometry( v.coordinates().clone() );
+          }
         }
       }
 
       // for polygons show midpoint if previous or next vertex is not active
       if ( mRecordedGeometry.type() == QgsWkbTypes::PolygonGeometry )
       {
-        Vertex prevVertex = mVertices.at( i - 1 );
-
-        // next vertex should be the either the next vertex in the sequence
-        // if this midpoint is a first or middle midpoint of the ring or
-        // it should be the first vertex of the correspoding ring is this
-        // midpoint is the last midpoint of the ring
-        Vertex nextVertex = mVertices.at( i + 1 );
-        if ( nextVertex.vertexId().part != v.vertexId().part || nextVertex.vertexId().ring != v.vertexId().ring )
+        if ( i > 0 && i < mVertices.count() - 1 )
         {
-          for ( int j = 0 ; j < mVertices.count(); j++ )
+          Vertex prevVertex = mVertices.at( i - 1 );
+
+          // next vertex should be the either the next vertex in the sequence
+          // if this midpoint is a first or middle midpoint of the ring or
+          // it should be the first vertex of the correspoding ring is this
+          // midpoint is the last midpoint of the ring
+          Vertex nextVertex = mVertices.at( i + 1 );
+          if ( nextVertex.vertexId().part != v.vertexId().part || nextVertex.vertexId().ring != v.vertexId().ring )
           {
-            nextVertex = mVertices.at( j );
-            if ( nextVertex.vertexId().part == v.vertexId().part && nextVertex.vertexId().ring == v.vertexId().ring )
+            for ( int j = 0 ; j < mVertices.count(); j++ )
             {
-              break;
+              nextVertex = mVertices.at( j );
+              if ( nextVertex.vertexId().part == v.vertexId().part && nextVertex.vertexId().ring == v.vertexId().ring )
+              {
+                break;
+              }
             }
           }
-        }
 
-        if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
-        {
-          midPoints->addGeometry( v.coordinates().clone() );
+          if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
+          {
+            midPoints->addGeometry( v.coordinates().clone() );
+          }
         }
       }
-
     }
     else if ( v.type() == Vertex::HandleStart )
     {
@@ -1110,6 +1115,10 @@ void RecordingMapTool::updateActiveVertexGeometry()
   if ( mActiveVertex.isValid() )
   {
     setActiveVertexGeometry( QgsGeometry( mActiveVertex.coordinates().clone() ) );
+  }
+  else
+  {
+    setActiveVertexGeometry( QgsGeometry() );
   }
 }
 

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -698,9 +698,11 @@ void RecordingMapTool::updateVisibleItems()
   }
 
   Vertex v;
+  qDebug() << "COUNT" << mVertices.count();
   for ( int i = 0; i < mVertices.count(); i++ )
   {
     v = mVertices.at( i );
+    qDebug() << i << v.type() << v.coordinates().asWkt(8);
 
     if ( v.type() == Vertex::Existing && v != mActiveVertex )
     {
@@ -729,6 +731,7 @@ void RecordingMapTool::updateVisibleItems()
         if ( i > 0 && i < mVertices.count() )
         {
           Vertex prevVertex = mVertices.at( i - 1 );
+          qDebug() << "PREV" << i - 1 << prevVertex.type() << prevVertex.coordinates().asWkt(8);
 
           // next vertex should be the either the next vertex in the sequence
           // if this midpoint is a first or middle midpoint of the ring or
@@ -737,6 +740,7 @@ void RecordingMapTool::updateVisibleItems()
           Vertex nextVertex = mVertices.at( i + 1 );
           if ( nextVertex.vertexId().part != v.vertexId().part || nextVertex.vertexId().ring != v.vertexId().ring )
           {
+            qDebug() << "FIND FIRST";
             for ( int j = 0 ; j < mVertices.count(); j++ )
             {
               nextVertex = mVertices.at( j );
@@ -746,6 +750,7 @@ void RecordingMapTool::updateVisibleItems()
               }
             }
           }
+          qDebug() << "NEXT" << i - 1 << nextVertex.type() << nextVertex.coordinates().asWkt(8);
 
           if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
           {

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -227,7 +227,6 @@ void RecordingMapTool::removePoint()
   if ( mState == MapToolState::Grab )
   {
     // we are removing existing vertex selected by ActiveVertex
-
     if ( !mActiveVertex.isValid() )
     {
       return;
@@ -344,7 +343,14 @@ void RecordingMapTool::removePoint()
     else
     {
       // points / multipoints
-      mRecordedGeometry.get()->deleteVertex( current );
+      if ( mRecordedGeometry.isMultipart() )
+      {
+        mRecordedGeometry.deletePart( current.part );
+      }
+      else
+      {
+        mRecordedGeometry = QgsGeometry();
+      }
     }
 
     mActiveLayer->beginEditCommand( QStringLiteral( "Delete vertex" ) );

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -29,6 +29,7 @@ RecordingMapTool::RecordingMapTool( QObject *parent )
   connect( this, &RecordingMapTool::recordedGeometryChanged, this, &RecordingMapTool::completeEditOperation );
   connect( this, &RecordingMapTool::recordedGeometryChanged, this, &RecordingMapTool::collectVertices );
   connect( this, &RecordingMapTool::activeVertexChanged, this, &RecordingMapTool::updateVisibleItems );
+  connect( this, &RecordingMapTool::activeVertexChanged, this, &RecordingMapTool::updateActiveVertexGeometry );
   connect( this, &RecordingMapTool::stateChanged, this, &RecordingMapTool::updateVisibleItems );
 }
 
@@ -1035,6 +1036,14 @@ void RecordingMapTool::undo()
   }
 }
 
+void RecordingMapTool::updateActiveVertexGeometry()
+{
+  if ( mActiveVertex.isValid() )
+  {
+    setActiveVertexGeometry( QgsGeometry( mActiveVertex.coordinates().clone() ) );
+  }
+}
+
 Vertex::Vertex()
 {
 
@@ -1234,6 +1243,18 @@ void RecordingMapTool::setActiveVertex( const Vertex &newActiveVertex )
   emit activeVertexChanged( mActiveVertex );
 }
 
+const QgsGeometry &RecordingMapTool::activeVertexGeometry() const
+{
+  return mActiveVertexGeometry;
+}
+
+void RecordingMapTool::setActiveVertexGeometry( const QgsGeometry &newActiveVertexGeometry )
+{
+  if ( mActiveVertexGeometry.equals( newActiveVertexGeometry ) )
+    return;
+  mActiveVertexGeometry = newActiveVertexGeometry;
+  emit recordedGeometryChanged( mActiveVertexGeometry );
+}
 
 const QgsVertexId &Vertex::vertexId() const
 {

--- a/app/maptools/recordingmaptool.cpp
+++ b/app/maptools/recordingmaptool.cpp
@@ -693,7 +693,28 @@ void RecordingMapTool::updateVisibleItems()
     }
     else if ( v.type() == Vertex::MidPoint )
     {
-      midPoints->addGeometry( v.coordinates().clone() );
+      // for lines show midpoint if previous or next vertex is not active
+      if ( mRecordedGeometry.type() == QgsWkbTypes::LineGeometry )
+      {
+        Vertex prevVertex = mVertices.at( i - 1 );
+        Vertex nextVertex = mVertices.at( i + 1 );
+        if ( prevVertex != mActiveVertex && nextVertex != mActiveVertex )
+        {
+          midPoints->addGeometry( v.coordinates().clone() );
+        }
+      }
+
+      if ( mRecordedGeometry.type() == QgsWkbTypes::PolygonGeometry )
+      {
+        if ( mRecordedGeometry.isMultipart() )
+        {
+        }
+        else
+        {
+        }
+        midPoints->addGeometry( v.coordinates().clone() );
+      }
+
     }
     else if ( v.type() == Vertex::HandleStart )
     {

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -92,6 +92,7 @@ class RecordingMapTool : public AbstractMapTool
     Q_PROPERTY( QgsGeometry handles READ handles WRITE setHandles NOTIFY handlesChanged )
 
     Q_PROPERTY( Vertex activeVertex READ activeVertex WRITE setActiveVertex NOTIFY activeVertexChanged )
+    Q_PROPERTY( QgsGeometry activeVertexGeometry READ activeVertexGeometry WRITE setActiveVertexGeometry NOTIFY activeVertexGeometryChanged )
     Q_PROPERTY( InsertPolicy insertPolicy READ insertPolicy WRITE setInsertPolicy NOTIFY insertPolicyChanged )
 
     Q_PROPERTY( MapToolState state READ state WRITE setState NOTIFY stateChanged )
@@ -215,6 +216,9 @@ class RecordingMapTool : public AbstractMapTool
     const Vertex &activeVertex() const;
     void setActiveVertex( const Vertex &newActiveVertex );
 
+    const QgsGeometry &activeVertexGeometry() const;
+    void setActiveVertexGeometry( const QgsGeometry &newActiveVertexGeometry );
+
     const InsertPolicy &insertPolicy() const;
     void setInsertPolicy( const InsertPolicy &insertPolicy );
 
@@ -247,6 +251,7 @@ class RecordingMapTool : public AbstractMapTool
     void recordPointChanged( QgsPoint recordPoint );
 
     void activeVertexChanged( const Vertex &activeVertex );
+    void activeVertexGeometryChanged( const QgsGeometry &activeVertexGeometry );
 
     void insertPolicyChanged( const RecordingMapTool::InsertPolicy &insertPolicy );
 
@@ -275,6 +280,11 @@ class RecordingMapTool : public AbstractMapTool
      * start/end points and "handles" (for lines) from the nodes index.
      */
     void updateVisibleItems();
+
+    /**
+     * Updates geometry of the active vertex
+     */
+    void updateActiveVertexGeometry();
 
     /**
      * Grabs next vertex after the removal of the currently selected vertex
@@ -323,6 +333,7 @@ class RecordingMapTool : public AbstractMapTool
     // ActiveVertex is set only when we grab a point,
     // it is the grabbed point, contains its coordinates and index
     Vertex mActiveVertex;
+    QgsGeometry mActiveVertexGeometry;
 
     // ActiveRing and ActivePart are set only when we record,
     // in order to know where to insert the points

--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -160,6 +160,10 @@ class RecordingMapTool : public AbstractMapTool
      */
     Q_INVOKABLE void releaseVertex( const QgsPoint &point );
 
+    Q_INVOKABLE FeatureLayerPair commitChanges();
+
+    Q_INVOKABLE void rollbackChanges();
+
     /**
      * Reverts last change from the layer undo stack.
      */

--- a/app/qml/form/FeatureToolbar.qml
+++ b/app/qml/form/FeatureToolbar.qml
@@ -151,6 +151,8 @@ Item {
         }
     }
 
+    // TODO: remove this item if layer does not have geometry
+
     Menu {
         id: rootMenu
         title: qsTr("Advanced")

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -782,12 +782,6 @@ Item {
         }
         else if ( root.state === "edit" )
         {
-          if ( internal.oldGeometry )
-          {
-            let editedFeaturePair = __inputUtils.changeFeaturePairGeometry( internal.featurePairToEdit, internal.oldGeometry )
-            internal.oldGeometry = null
-            root.editingGeometryFinished( editedFeaturePair )
-          }
           root.editingGeometryCanceled()
         }
         else if ( root.state === "recordInLayer" )
@@ -801,18 +795,15 @@ Item {
       onDone: {
         if ( root.state === "record" )
         {
-          let newFeaturePair = __inputUtils.createFeatureLayerPair( __activeLayer.vectorLayer, geometry, __variablesManager )
-          root.recordingFinished( newFeaturePair )
+          root.recordingFinished( featureLayerPair )
         }
         else if ( root.state === "edit" )
         {
-          let editedFeaturePair = __inputUtils.changeFeaturePairGeometry( internal.featurePairToEdit, geometry )
-          root.editingGeometryFinished( editedFeaturePair )
+          root.editingGeometryFinished( featureLayerPair )
         }
         else if ( root.state === "recordInLayer" )
         {
-          let newFeaturePair = __inputUtils.createFeatureLayerPair( __activeLayer.vectorLayer, geometry, __variablesManager )
-          root.recordInLayerFeatureFinished( newFeaturePair )
+          root.recordInLayerFeatureFinished( featureLayerPair )
         }
 
         root.state = "view"
@@ -882,7 +873,6 @@ Item {
     property var stakeoutTarget
 
     property bool isInRecordState: root.state === "record" || root.state === "recordInLayer" || root.state === "edit"
-    property var oldGeometry: null // geometry of the feature before redraw
   }
 
   function select( featurepair ) {
@@ -913,9 +903,6 @@ Item {
     __activeProject.setActiveLayer( featurepair.layer )
     centerToPair( featurepair )
     redrawGeometryBanner.show()
-
-    // save existing geometry, so we can restore it on cancel
-    internal.oldGeometry = featurepair.feature.geometry
 
     // clear feature geometry
     internal.featurePairToEdit = __inputUtils.changeFeaturePairGeometry( featurepair, __inputUtils.emptyGeometry() )

--- a/app/qml/map/RecordingToolbar.qml
+++ b/app/qml/map/RecordingToolbar.qml
@@ -158,8 +158,6 @@ Item {
             Layout.fillWidth: true
             height: parent.height
 
-            visible: root.pointLayerSelected ? false : true
-
             MainPanelButton {
                 id: finishButton
                 width: root.itemSize

--- a/app/qml/map/RecordingToolbar.qml
+++ b/app/qml/map/RecordingToolbar.qml
@@ -104,7 +104,6 @@ Item {
         Item {
             Layout.fillWidth: true
             height: parent.height
-            visible: root.pointLayerSelected ? false : true
 
             MainPanelButton {
                 id: removeButton

--- a/app/qml/map/RecordingToolbar.qml
+++ b/app/qml/map/RecordingToolbar.qml
@@ -104,6 +104,7 @@ Item {
         Item {
             Layout.fillWidth: true
             height: parent.height
+            visible: root.pointLayerSelected ? false : true
 
             MainPanelButton {
                 id: removeButton

--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -29,7 +29,7 @@ Item {
   property var activeFeature
 
   signal canceled()
-  signal done( var geometry )
+  signal done( var featureLayerPair )
 
   Banner {
     id: gpsAccuracyBanner
@@ -257,6 +257,10 @@ Item {
           mapTool.releaseVertex( crosshair.recordPoint )
         }
 
+        // TODO: mapTool.commitChanges
+        // let pair = mapTool.commitChanges()
+        // root.done( pair )
+
         root.done( mapTool.recordedGeometry )
       }
       else
@@ -266,12 +270,7 @@ Item {
     }
 
     onCancelClicked: {
-      if ( mapTool.state == RecordingMapTool.Grab )
-      {
-        mapTool.cancelGrab()
-        return;
-      }
-
+      // TODO: mapTool.rollbackChanges
       root.canceled()
     }
   }

--- a/app/test/testmaptools.cpp
+++ b/app/test/testmaptools.cpp
@@ -289,7 +289,6 @@ void TestMapTools::testExistingVertices()
   QVERIFY( polygonLayer->isValid() );
   project->addMapLayer( polygonLayer );
 
-  qDebug() << "EXISTING VERTICES POLYGON";
   mapTool.setActiveLayer( polygonLayer );
   mapTool.setActiveFeature( polyFeature );
 
@@ -300,51 +299,51 @@ void TestMapTools::testExistingVertices()
   QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 0, 1 ) );
   QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 1, 1 ) );
 
-  //~ // line
-  //~ QgsVectorLayer *lineLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
-  //~ QgsLineString *line = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 0, 0 ) << QgsPoint( 0, 1 ) << QgsPoint( 1, 1 ) << QgsPoint( 2, 2 ) );
-  //~ geometry.set( line );
+  // line
+  QgsVectorLayer *lineLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
+  QgsLineString *line = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 0, 0 ) << QgsPoint( 0, 1 ) << QgsPoint( 1, 1 ) << QgsPoint( 2, 2 ) );
+  geometry.set( line );
 
-  //~ QgsFeature lineFeature;
-  //~ lineFeature.setGeometry( geometry );
-  //~ lineLayer->dataProvider()->addFeature( lineFeature );
-  //~ QVERIFY( lineLayer->isValid() );
-  //~ project->addMapLayer( lineLayer );
+  QgsFeature lineFeature;
+  lineFeature.setGeometry( geometry );
+  lineLayer->dataProvider()->addFeature( lineFeature );
+  QVERIFY( lineLayer->isValid() );
+  project->addMapLayer( lineLayer );
 
-  //~ mapTool.setActiveLayer( lineLayer );
-  //~ mapTool.setActiveFeature( lineFeature );
+  mapTool.setActiveLayer( lineLayer );
+  mapTool.setActiveFeature( lineFeature );
 
-  //~ vertices = mapTool.existingVertices();
-  //~ QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
-  //~ QCOMPARE( vertices.constGet()->partCount(), 4 );
-  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
-  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 0, 1 ) );
-  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 1, 1 ) );
-  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 3, 0, 0 ) ), QgsPoint( 2, 2 ) );
+  vertices = mapTool.existingVertices();
+  QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
+  QCOMPARE( vertices.constGet()->partCount(), 4 );
+  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
+  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 0, 1 ) );
+  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 1, 1 ) );
+  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 3, 0, 0 ) ), QgsPoint( 2, 2 ) );
 
-  //~ // multipoint
-  //~ QgsVectorLayer *pointLayer = new QgsVectorLayer( QStringLiteral( "MultiPoint?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
-  //~ geometry = QgsGeometry::fromWkt( "MultiPoint( 0 0, 1 1, 2 2)" );
+  // multipoint
+  QgsVectorLayer *pointLayer = new QgsVectorLayer( QStringLiteral( "MultiPoint?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
+  geometry = QgsGeometry::fromWkt( "MultiPoint( 0 0, 1 1, 2 2)" );
 
-  //~ QgsFeature pointFeature;
-  //~ pointFeature.setGeometry( geometry );
-  //~ pointLayer->dataProvider()->addFeature( pointFeature );
-  //~ QVERIFY( pointLayer->isValid() );
-  //~ project->addMapLayer( pointLayer );
+  QgsFeature pointFeature;
+  pointFeature.setGeometry( geometry );
+  pointLayer->dataProvider()->addFeature( pointFeature );
+  QVERIFY( pointLayer->isValid() );
+  project->addMapLayer( pointLayer );
 
-  //~ mapTool.setActiveLayer( pointLayer );
-  //~ mapTool.setActiveFeature( pointFeature );
+  mapTool.setActiveLayer( pointLayer );
+  mapTool.setActiveFeature( pointFeature );
 
-  //~ vertices = mapTool.existingVertices();
-  //~ QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
-  //~ QCOMPARE( vertices.constGet()->partCount(), 3 );
-  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
-  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 1, 1 ) );
-  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 2, 2 ) );
+  vertices = mapTool.existingVertices();
+  QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
+  QCOMPARE( vertices.constGet()->partCount(), 3 );
+  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
+  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 1, 1 ) );
+  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 2, 2 ) );
 
   delete polygonLayer;
-  //~ delete lineLayer;
-  //~ delete pointLayer;
+  delete lineLayer;
+  delete pointLayer;
 }
 
 void TestMapTools::testMidSegmentVertices()

--- a/app/test/testmaptools.cpp
+++ b/app/test/testmaptools.cpp
@@ -300,46 +300,46 @@ void TestMapTools::testExistingVertices()
   QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 1, 1 ) );
 
   // line
-  QgsVectorLayer *lineLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
-  QgsLineString *line = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 0, 0 ) << QgsPoint( 0, 1 ) << QgsPoint( 1, 1 ) << QgsPoint( 2, 2 ) );
-  geometry.set( line );
+  //~ QgsVectorLayer *lineLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
+  //~ QgsLineString *line = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 0, 0 ) << QgsPoint( 0, 1 ) << QgsPoint( 1, 1 ) << QgsPoint( 2, 2 ) );
+  //~ geometry.set( line );
 
-  QgsFeature lineFeature;
-  lineFeature.setGeometry( geometry );
-  lineLayer->dataProvider()->addFeature( lineFeature );
-  QVERIFY( lineLayer->isValid() );
-  project->addMapLayer( lineLayer );
+  //~ QgsFeature lineFeature;
+  //~ lineFeature.setGeometry( geometry );
+  //~ lineLayer->dataProvider()->addFeature( lineFeature );
+  //~ QVERIFY( lineLayer->isValid() );
+  //~ project->addMapLayer( lineLayer );
 
-  mapTool.setActiveLayer( lineLayer );
-  mapTool.setActiveFeature( lineFeature );
+  //~ mapTool.setActiveLayer( lineLayer );
+  //~ mapTool.setActiveFeature( lineFeature );
 
-  vertices = mapTool.existingVertices();
-  QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
-  QCOMPARE( vertices.constGet()->partCount(), 4 );
-  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
-  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 0, 1 ) );
-  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 1, 1 ) );
-  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 3, 0, 0 ) ), QgsPoint( 2, 2 ) );
+  //~ vertices = mapTool.existingVertices();
+  //~ QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
+  //~ QCOMPARE( vertices.constGet()->partCount(), 4 );
+  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
+  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 0, 1 ) );
+  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 1, 1 ) );
+  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 3, 0, 0 ) ), QgsPoint( 2, 2 ) );
 
-  // multipoint
-  QgsVectorLayer *pointLayer = new QgsVectorLayer( QStringLiteral( "MultiPoint?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
-  geometry = QgsGeometry::fromWkt( "MultiPoint( 0 0, 1 1, 2 2)" );
+  //~ // multipoint
+  //~ QgsVectorLayer *pointLayer = new QgsVectorLayer( QStringLiteral( "MultiPoint?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
+  //~ geometry = QgsGeometry::fromWkt( "MultiPoint( 0 0, 1 1, 2 2)" );
 
-  QgsFeature pointFeature;
-  pointFeature.setGeometry( geometry );
-  pointLayer->dataProvider()->addFeature( pointFeature );
-  QVERIFY( pointLayer->isValid() );
-  project->addMapLayer( pointLayer );
+  //~ QgsFeature pointFeature;
+  //~ pointFeature.setGeometry( geometry );
+  //~ pointLayer->dataProvider()->addFeature( pointFeature );
+  //~ QVERIFY( pointLayer->isValid() );
+  //~ project->addMapLayer( pointLayer );
 
-  mapTool.setActiveLayer( pointLayer );
-  mapTool.setActiveFeature( pointFeature );
+  //~ mapTool.setActiveLayer( pointLayer );
+  //~ mapTool.setActiveFeature( pointFeature );
 
-  vertices = mapTool.existingVertices();
-  QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
-  QCOMPARE( vertices.constGet()->partCount(), 3 );
-  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
-  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 1, 1 ) );
-  QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 2, 2 ) );
+  //~ vertices = mapTool.existingVertices();
+  //~ QCOMPARE( vertices.wkbType(), QgsWkbTypes::MultiPoint );
+  //~ QCOMPARE( vertices.constGet()->partCount(), 3 );
+  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0, 0 ) );
+  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 1, 1 ) );
+  //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 2, 2 ) );
 
   delete polygonLayer;
   delete lineLayer;

--- a/app/test/testmaptools.cpp
+++ b/app/test/testmaptools.cpp
@@ -289,6 +289,7 @@ void TestMapTools::testExistingVertices()
   QVERIFY( polygonLayer->isValid() );
   project->addMapLayer( polygonLayer );
 
+  qDebug() << "EXISTING VERTICES POLYGON";
   mapTool.setActiveLayer( polygonLayer );
   mapTool.setActiveFeature( polyFeature );
 
@@ -299,7 +300,7 @@ void TestMapTools::testExistingVertices()
   QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 1, 0, 0 ) ), QgsPoint( 0, 1 ) );
   QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 1, 1 ) );
 
-  // line
+  //~ // line
   //~ QgsVectorLayer *lineLayer = new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:4326" ), QString(), QStringLiteral( "memory" ) );
   //~ QgsLineString *line = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 0, 0 ) << QgsPoint( 0, 1 ) << QgsPoint( 1, 1 ) << QgsPoint( 2, 2 ) );
   //~ geometry.set( line );

--- a/app/test/testmaptools.cpp
+++ b/app/test/testmaptools.cpp
@@ -342,8 +342,8 @@ void TestMapTools::testExistingVertices()
   //~ QCOMPARE( vertices.constGet()->vertexAt( QgsVertexId( 2, 0, 0 ) ), QgsPoint( 2, 2 ) );
 
   delete polygonLayer;
-  delete lineLayer;
-  delete pointLayer;
+  //~ delete lineLayer;
+  //~ delete pointLayer;
 }
 
 void TestMapTools::testMidSegmentVertices()


### PR DESCRIPTION
Fixes some issues in geometry editing:

- expose active vertex geometry as a map tool property
- hide midpoints around active vertex
- fix removal of points in single- and multipart point geometries
- fix saving geometry changes in multipoint layers
- fix creation of empty multipart polygons (fixes redrawing)
- when editing singlepart point layer start edit with grabbed point