### PR TITLE
Fix upload to artifacts on Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -210,13 +210,13 @@ jobs:
       - name: Upload v8 APK to Artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/build-apk-arm64-v8a/input/out/build/outputs/apk/release/out-release-signed.apk
+          path: ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release/out-release-signed.apk
           name: arm64 apk
 
       - name: Upload v7 APK to Artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/build-apk-armeabi-v7a/input/out/build/outputs/apk/release/out-release-signed.apk
+          path: ${{ github.workspace }}/build-apk-armeabi-v7a/build-input-apk/out/build/outputs/apk/release/out-release-signed.apk
           name: armeabi apk
 
       - name: Download repo history
@@ -260,7 +260,7 @@ jobs:
         if: ${{ env.GIT_BRANCH }} == "master"
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/build-aab/input/out/build/outputs/bundle/release/out-release.aab
+          path: ${{ github.workspace }}/build-aab/build-input-aab/out/build/outputs/bundle/release/out-release.aab
           name: aab bundle
 
       - name: Check generated files

--- a/scripts/android-aab.bash
+++ b/scripts/android-aab.bash
@@ -4,7 +4,7 @@
 # Have a look at android-apk.bash script to see all required environment variables!
 # ----
 
-BUILD_DIR=`pwd`/input
+BUILD_DIR=`pwd`/build-input-aab
 INSTALL_DIR=${BUILD_DIR}/out
 
 set -e

--- a/scripts/android-apk.bash
+++ b/scripts/android-apk.bash
@@ -14,7 +14,7 @@
 # optional:
 # CORES, number of cores to use
 
-BUILD_DIR=`pwd`/build-input
+BUILD_DIR=`pwd`/build-input-apk
 INSTALL_DIR=${BUILD_DIR}/out
 
 set -e


### PR DESCRIPTION
Scripts to build apk/aab were previously changed (build path has changed), but workflow uploaders were not updated correspondingly. PR unifies those paths and updates the workflow file.