### PR TITLE
Fix ios submission & rename artefacts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -227,13 +227,13 @@ jobs:
       - name: Upload v8 APK to Artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release/merginmaps-v8-$CI_VERSION_CODE.apk
+          path: ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release/merginmaps-v8-${{ env.CI_VERSION_CODE }}.apk
           name: arm64 apk
 
       - name: Upload v7 APK to Artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/build-apk-armeabi-v7a/build-input-apk/out/build/outputs/apk/release/merginmaps-v7a-$CI_VERSION_CODE.apk
+          path: ${{ github.workspace }}/build-apk-armeabi-v7a/build-input-apk/out/build/outputs/apk/release/merginmaps-v7a-${{ env.CI_VERSION_CODE }}.apk
           name: armeabi apk
 
       - name: Build AAB

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -203,10 +203,6 @@ jobs:
             cd ${{ github.workspace }}/build-apk-$ARCH
             ../scripts/android-apk.bash
 
-            # rename generated file
-            cd ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release
-            mv out-release-signed.apk merginmaps-v7a-$CI_VERSION_CODE.apk
-
       - name: Build arm64-v8a APK
         env:
           ARCH: arm64-v8a
@@ -220,9 +216,13 @@ jobs:
             cd ${{ github.workspace }}/build-apk-$ARCH
             ../scripts/android-apk.bash
 
-            # rename generated file
-            cd ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release
-            mv out-release-signed.apk merginmaps-v8-$CI_VERSION_CODE.apk
+      - name: Rename build artefacts
+        run: |
+          cd ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release
+          mv out-release-signed.apk `echo merginmaps-v8-$CI_VERSION_CODE.apk`
+          
+          cd ${{ github.workspace }}/build-apk-armeabi-v7a/build-input-apk/out/build/outputs/apk/release/
+          mv out-release-signed.apk `echo merginmaps-v7a-$CI_VERSION_CODE.apk`
 
       - name: Upload v8 APK to Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -180,6 +180,15 @@ jobs:
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 
+      - name: Calculate build number
+        env:
+          OFFFSET: 10 # offset for build number - due to previous builds ~ new builds must always have a higher number
+        run: |
+            BUILD_NUM=$GITHUB_RUN_NUMBER$((GITHUB_RUN_ATTEMPT + OFFFSET))
+            echo "CI_VERSION_CODE=${BUILD_NUM}" >> $GITHUB_ENV
+
+            echo "Build number: ${BUILD_NUM}"
+
       - name: Build armeabi-v7a APK
         env:
           ARCH: armeabi-v7a
@@ -219,29 +228,8 @@ jobs:
           path: ${{ github.workspace }}/build-apk-armeabi-v7a/build-input-apk/out/build/outputs/apk/release/out-release-signed.apk
           name: armeabi apk
 
-      - name: Download repo history
-        if: ${{ env.GIT_BRANCH }} == "master"
-        uses: actions/checkout@v2
-        with:
-          path: input-history
-          fetch-depth: 0 # fetch all history
-
-      - name: Calculate version code
-        if: ${{ env.GIT_BRANCH }} == "master"
-        env:
-          START_VERSION_OFFSET: 110000 # offset for build version number - due to previous builds
-        run: |
-            cd input-history
-
-            NUM_OF_COMMITS=`git rev-list --count --all`
-            
-            VERSION_CODE=$((START_VERSION_OFFSET + NUM_OF_COMMITS))
-
-            echo "CI_VERSION_CODE=${VERSION_CODE}" >> $GITHUB_ENV
-            echo "Building version: ${VERSION_CODE}"
-
       - name: Build AAB
-        if: ${{ env.GIT_BRANCH }} == "master"
+        if: github.ref_name == "master" || github.ref_type == "tag"
         env:
           ARCH: 'armeabi-v7a arm64-v8a'
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
@@ -257,12 +245,8 @@ jobs:
             ../scripts/android-aab.bash
 
       - name: Upload AAB to Artifacts
-        if: ${{ env.GIT_BRANCH }} == "master"
+        if: github.ref_name == "master" || github.ref_type == "tag"
         uses: actions/upload-artifact@v2
         with:
           path: ${{ github.workspace }}/build-aab/build-input-aab/out/build/outputs/bundle/release/out-release.aab
           name: aab bundle
-
-      - name: Check generated files
-        run: |
-            find ${{ github.workspace }}/build-* -name "*.apk" -or -name "*.aab"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -203,6 +203,10 @@ jobs:
             cd ${{ github.workspace }}/build-apk-$ARCH
             ../scripts/android-apk.bash
 
+            # rename generated file
+            cd ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release
+            mv out-release-signed.apk merginmaps-v7a-$CI_VERSION_CODE.apk
+
       - name: Build arm64-v8a APK
         env:
           ARCH: arm64-v8a
@@ -216,16 +220,20 @@ jobs:
             cd ${{ github.workspace }}/build-apk-$ARCH
             ../scripts/android-apk.bash
 
+            # rename generated file
+            cd ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release
+            mv out-release-signed.apk merginmaps-v8-$CI_VERSION_CODE.apk
+
       - name: Upload v8 APK to Artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release/out-release-signed.apk
+          path: ${{ github.workspace }}/build-apk-arm64-v8a/build-input-apk/out/build/outputs/apk/release/merginmaps-v8-$CI_VERSION_CODE.apk
           name: arm64 apk
 
       - name: Upload v7 APK to Artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/build-apk-armeabi-v7a/build-input-apk/out/build/outputs/apk/release/out-release-signed.apk
+          path: ${{ github.workspace }}/build-apk-armeabi-v7a/build-input-apk/out/build/outputs/apk/release/merginmaps-v7a-$CI_VERSION_CODE.apk
           name: armeabi apk
 
       - name: Build AAB

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -229,7 +229,7 @@ jobs:
           name: armeabi apk
 
       - name: Build AAB
-        if: github.ref_name == "master" || github.ref_type == "tag"
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         env:
           ARCH: 'armeabi-v7a arm64-v8a'
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
@@ -245,7 +245,7 @@ jobs:
             ../scripts/android-aab.bash
 
       - name: Upload AAB to Artifacts
-        if: github.ref_name == "master" || github.ref_type == "tag"
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         uses: actions/upload-artifact@v2
         with:
           path: ${{ github.workspace }}/build-aab/build-input-aab/out/build/outputs/bundle/release/out-release.aab

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -193,31 +193,22 @@ jobs:
             exit 1
           fi
 
-      - name: Download repo history
-        uses: actions/checkout@v2
-        with:
-          path: input-history
-          fetch-depth: 0 # fetch all history
+      - name: Calculate build number
+        env:
+          OFFFSET: 10 # offset for build number - due to previous builds ~ new builds must always have a higher number
+        run: |
+            BUILD_NUM=$GITHUB_RUN_NUMBER$((GITHUB_RUN_ATTEMPT + OFFFSET))
+
+            TIMESTAMP=`date "+%y.%m"`
+            CF_BUNDLE_VERSION=${TIMESTAMP}.${BUILD_NUM}
+
+            echo "CF_BUNDLE_VERSION=${CF_BUNDLE_VERSION}" >> $GITHUB_ENV
+
+            echo "Build number: ${CF_BUNDLE_VERSION}"
 
       - name: Create build system with 
-        env:
-          START_VERSION_OFFSET: 110000 # offset for build version number - due to previous builds
         run: |
           INPUT_DIR=`pwd`
-
-          # calculate CF_BUNDLE_VERSION
-          cd input-history
-          NUM_OF_COMMITS=`git rev-list --count --all`
-          echo "#commits inside $NUM_OF_COMMITS `pwd`"
-          cd ..
-
-          echo "#commits outside `git rev-list --count --all` `pwd`"
-
-          VERSION_CODE=$((START_VERSION_OFFSET + NUM_OF_COMMITS))
-          echo "#vc $VERSION_CODE"
-          TIMESTAMP=`date "+%y.%m"`
-
-          CF_BUNDLE_VERSION=${TIMESTAMP}.${VERSION_CODE}
 
           # patch the Info.plist
           CF_BUNDLE_SHORT_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $INPUT_DIR/app/ios/Info.plist`

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -208,7 +208,7 @@ jobs:
           mkdir -p build-INPUT
           cd build-INPUT
 
-          run qmake
+          # run qmake
           ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/bin/qmake \
             ${INPUT_DIR}/app/input.pro \
             -spec macx-ios-clang \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -33,13 +33,14 @@ jobs:
     steps:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XC_VERSION.app"
+        if: off
 
       - uses: actions/checkout@v2
 
       # CCache
       - name: Prepare build cache for pull request
         uses: pat-s/always-upload-cache@v2.1.5
-        if: github.event_name == 'pull_request'
+        if: false
         with:
           path: ${{ env.CCACHE_DIR }}
           key: build-ios-ccache-${{ github.actor }}-${{ github.head_ref }}-${{ github.sha }}
@@ -53,7 +54,7 @@ jobs:
       - name: Prepare build cache for branch/tag
         # use a fork of actions/cache@v2 to upload cache even when the build or test failed
         uses: pat-s/always-upload-cache@v2.1.5
-        if: github.event_name != 'pull_request'
+        if: off
         with:
           path: ${{ env.CCACHE_DIR }}
           # The branch or tag ref that triggered the workflow run. For branches this in the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>
@@ -63,6 +64,7 @@ jobs:
             build-ios-ccache-refs/heads/master-
 
       - name: Install brew deps
+        if: off
         run: |
           brew install gnupg
           brew install openssl@1.1
@@ -70,12 +72,14 @@ jobs:
           brew install ccache
 
       - name: Install ccache
+        if: off
         run: |
           mkdir -p ${CCACHE_DIR}
           ccache --set-config=max_size=2.0G
           ccache -s
 
       - name: Extract Mergin API_KEY
+        if: off
         env:
           MERGINSECRETS_DECRYPT_KEY: ${{ secrets.MERGINSECRETS_DECRYPT_KEY }}
         run: |
@@ -88,6 +92,7 @@ jobs:
               -md md5
 
       - name: Configure Keychain
+        if: off
         run: |
           security create-keychain -p "" "$KEYCHAIN"
           security list-keychains -s "$KEYCHAIN"
@@ -97,6 +102,7 @@ jobs:
           security list-keychains
 
       - name: Configure Code Signing
+        if: off
         env:
           IOS_GPG_KEY: ${{ secrets.IOS_GPG_KEY }}
           IOS_CERT_KEY: ${{ secrets.IOS_CERT_KEY }}
@@ -111,6 +117,7 @@ jobs:
 
       # Input SDK
       - name: Cache Input-SDK
+        if: off
         id: cache-input-sdk
         uses: pat-s/always-upload-cache@v2.1.5
         with:
@@ -118,7 +125,7 @@ jobs:
           key: ${{ runner.os }}-input-sdk-v1-${{ env.INPUT_SDK_VERSION }}-${{ env.CACHE_VERSION }}
 
       - name: Install Input-SDK
-        if: steps.cache-input-sdk.outputs.cache-hit != 'true'
+        if: off
         run: |
           wget -O \
             ${{ github.workspace }}/input-sdk.tar.gz \
@@ -131,12 +138,14 @@ jobs:
       - name: Cache Qt
         id: cache-qt
         uses: pat-s/always-upload-cache@v2.1.5
+        if: off
         with:
           path: ${{ github.workspace }}/Qt
           key: ${{ runner.os }}-QtCache-v1-${{ env.QT_VERSION }}-ios-${{ env.CACHE_VERSION }}
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
+        if: off
         with:
           version: ${{ env.QT_VERSION }}
           target: ios
@@ -148,6 +157,7 @@ jobs:
       # Do this only until we move from 5.14.2!!
       - name: Patch Qt!
         shell: bash
+        if: off
         run: |
           echo "Patch 5.14.2 see https://github.com/MerginMaps/input-sdk/issues/34"
 
@@ -165,6 +175,7 @@ jobs:
       # !! and ccache received all of the compilation flags that were supposed to go to clang.
       - name: Export app/config.pri
         shell: bash
+        if: off
         run: |
           touch ./app/config.pri
           echo -e "ios {"  >> ./app/config.pri
@@ -197,9 +208,11 @@ jobs:
           # calculate CF_BUNDLE_VERSION
           cd input-history
           NUM_OF_COMMITS=`git rev-list --count --all`
+          echo "#commits $NUM_OF_COMMITS"
           cd ..
 
           VERSION_CODE=$((START_VERSION_OFFSET + NUM_OF_COMMITS))
+          echo "#vc $VERSION_CODE"
           TIMESTAMP=`date "+%y.%m"`
 
           CF_BUNDLE_VERSION=${TIMESTAMP}.${VERSION_CODE}
@@ -214,31 +227,32 @@ jobs:
           cd build-INPUT
 
           # run qmake
-          ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/bin/qmake \
-            ${INPUT_DIR}/app/input.pro \
-            -spec macx-ios-clang \
-            CONFIG+=release \
-            CONFIG+=iphoneos \
-            CONFIG+=device \
-            CONFIG+=qtquickcompiler \
-            QMAKE_MAC_XCODE_SETTINGS+=qprofile \
-            qprofile.name=PROVISIONING_PROFILE_SPECIFIER \
-            qprofile.value="LutraConsultingLtd.Input.AppStore" \
-            QMAKE_MAC_XCODE_SETTINGS+=qteam \
-            qteam.name=DEVELOPMENT_TEAM \
-            qteam.value=79QMH2QRAH \
-            QMAKE_MAC_XCODE_SETTINGS+=qidentity \
-            qidentity.name=CODE_SIGN_IDENTITY \
-            qidentity.value="iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)" \
-            QMAKE_MAC_XCODE_SETTINGS+=qstyle \
-            qstyle.name=CODE_SIGN_STYLE \
-            qstyle.value=Manual
+          # ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/bin/qmake \
+          #   ${INPUT_DIR}/app/input.pro \
+          #   -spec macx-ios-clang \
+          #   CONFIG+=release \
+          #   CONFIG+=iphoneos \
+          #   CONFIG+=device \
+          #   CONFIG+=qtquickcompiler \
+          #   QMAKE_MAC_XCODE_SETTINGS+=qprofile \
+          #   qprofile.name=PROVISIONING_PROFILE_SPECIFIER \
+          #   qprofile.value="LutraConsultingLtd.Input.AppStore" \
+          #   QMAKE_MAC_XCODE_SETTINGS+=qteam \
+          #   qteam.name=DEVELOPMENT_TEAM \
+          #   qteam.value=79QMH2QRAH \
+          #   QMAKE_MAC_XCODE_SETTINGS+=qidentity \
+          #   qidentity.name=CODE_SIGN_IDENTITY \
+          #   qidentity.value="iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)" \
+          #   QMAKE_MAC_XCODE_SETTINGS+=qstyle \
+          #   qstyle.name=CODE_SIGN_STYLE \
+          #   qstyle.value=Manual
             
-          # Use old deprecated build system in XCode 13
-          /usr/libexec/PlistBuddy -c "Add :DisableBuildSystemDeprecationDiagnostic bool" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
-          /usr/libexec/PlistBuddy -c "Set :DisableBuildSystemDeprecationDiagnostic true" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+          # # Use old deprecated build system in XCode 13
+          # /usr/libexec/PlistBuddy -c "Add :DisableBuildSystemDeprecationDiagnostic bool" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+          # /usr/libexec/PlistBuddy -c "Set :DisableBuildSystemDeprecationDiagnostic true" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
               
       - name: Build Input
+        if: off
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
@@ -252,6 +266,7 @@ jobs:
             "OTHER_CODE_SIGN_FLAGS=--keychain '$KEYCHAIN'"
 
       - name: Create Input Package
+        if: off
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
@@ -267,7 +282,7 @@ jobs:
           INPUTAPP_BOT_APPLEID_PASS: ${{ secrets.INPUTAPP_BOT_APPLEID_PASS }}
           INPUTAPP_BOT_APPLEID_USER: ${{ secrets.INPUTAPP_BOT_APPLEID_USER }}
           INPUTAPP_BOT_GITHUB_TOKEN: ${{ secrets.INPUTAPP_BOT_GITHUB_TOKEN }}
-        if: success()
+        if: off
         run: |
           CF_BUNDLE_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" app/ios/Info.plist`
           echo "Publishing ios ${CF_BUNDLE_VERSION}"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XC_VERSION.app"
-        if: off
+        if: false
 
       - uses: actions/checkout@v2
 
@@ -54,7 +54,7 @@ jobs:
       - name: Prepare build cache for branch/tag
         # use a fork of actions/cache@v2 to upload cache even when the build or test failed
         uses: pat-s/always-upload-cache@v2.1.5
-        if: off
+        if: false
         with:
           path: ${{ env.CCACHE_DIR }}
           # The branch or tag ref that triggered the workflow run. For branches this in the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>
@@ -64,7 +64,7 @@ jobs:
             build-ios-ccache-refs/heads/master-
 
       - name: Install brew deps
-        if: off
+        if: false
         run: |
           brew install gnupg
           brew install openssl@1.1
@@ -72,14 +72,14 @@ jobs:
           brew install ccache
 
       - name: Install ccache
-        if: off
+        if: false
         run: |
           mkdir -p ${CCACHE_DIR}
           ccache --set-config=max_size=2.0G
           ccache -s
 
       - name: Extract Mergin API_KEY
-        if: off
+        if: false
         env:
           MERGINSECRETS_DECRYPT_KEY: ${{ secrets.MERGINSECRETS_DECRYPT_KEY }}
         run: |
@@ -92,7 +92,7 @@ jobs:
               -md md5
 
       - name: Configure Keychain
-        if: off
+        if: false
         run: |
           security create-keychain -p "" "$KEYCHAIN"
           security list-keychains -s "$KEYCHAIN"
@@ -102,7 +102,7 @@ jobs:
           security list-keychains
 
       - name: Configure Code Signing
-        if: off
+        if: false
         env:
           IOS_GPG_KEY: ${{ secrets.IOS_GPG_KEY }}
           IOS_CERT_KEY: ${{ secrets.IOS_CERT_KEY }}
@@ -117,7 +117,7 @@ jobs:
 
       # Input SDK
       - name: Cache Input-SDK
-        if: off
+        if: false
         id: cache-input-sdk
         uses: pat-s/always-upload-cache@v2.1.5
         with:
@@ -125,7 +125,7 @@ jobs:
           key: ${{ runner.os }}-input-sdk-v1-${{ env.INPUT_SDK_VERSION }}-${{ env.CACHE_VERSION }}
 
       - name: Install Input-SDK
-        if: off
+        if: false
         run: |
           wget -O \
             ${{ github.workspace }}/input-sdk.tar.gz \
@@ -138,14 +138,14 @@ jobs:
       - name: Cache Qt
         id: cache-qt
         uses: pat-s/always-upload-cache@v2.1.5
-        if: off
+        if: false
         with:
           path: ${{ github.workspace }}/Qt
           key: ${{ runner.os }}-QtCache-v1-${{ env.QT_VERSION }}-ios-${{ env.CACHE_VERSION }}
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
-        if: off
+        if: false
         with:
           version: ${{ env.QT_VERSION }}
           target: ios
@@ -157,7 +157,7 @@ jobs:
       # Do this only until we move from 5.14.2!!
       - name: Patch Qt!
         shell: bash
-        if: off
+        if: false
         run: |
           echo "Patch 5.14.2 see https://github.com/MerginMaps/input-sdk/issues/34"
 
@@ -175,7 +175,7 @@ jobs:
       # !! and ccache received all of the compilation flags that were supposed to go to clang.
       - name: Export app/config.pri
         shell: bash
-        if: off
+        if: false
         run: |
           touch ./app/config.pri
           echo -e "ios {"  >> ./app/config.pri
@@ -254,7 +254,7 @@ jobs:
           # /usr/libexec/PlistBuddy -c "Set :DisableBuildSystemDeprecationDiagnostic true" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
               
       - name: Build Input
-        if: off
+        if: false
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
@@ -268,7 +268,7 @@ jobs:
             "OTHER_CODE_SIGN_FLAGS=--keychain '$KEYCHAIN'"
 
       - name: Create Input Package
-        if: off
+        if: false
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
@@ -284,7 +284,7 @@ jobs:
           INPUTAPP_BOT_APPLEID_PASS: ${{ secrets.INPUTAPP_BOT_APPLEID_PASS }}
           INPUTAPP_BOT_APPLEID_USER: ${{ secrets.INPUTAPP_BOT_APPLEID_USER }}
           INPUTAPP_BOT_GITHUB_TOKEN: ${{ secrets.INPUTAPP_BOT_GITHUB_TOKEN }}
-        if: off
+        if: false
         run: |
           CF_BUNDLE_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" app/ios/Info.plist`
           echo "Publishing ios ${CF_BUNDLE_VERSION}"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -199,7 +199,7 @@ jobs:
           path: input-history
           fetch-depth: 0 # fetch all history
 
-      - name: Create build system with qmake
+      - name: Create build system with 
         env:
           START_VERSION_OFFSET: 110000 # offset for build version number - due to previous builds
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -208,8 +208,10 @@ jobs:
           # calculate CF_BUNDLE_VERSION
           cd input-history
           NUM_OF_COMMITS=`git rev-list --count --all`
-          echo "#commits $NUM_OF_COMMITS"
+          echo "#commits inside $NUM_OF_COMMITS `pwd`"
           cd ..
+
+          echo "#commits outside `git rev-list --count --all` `pwd`"
 
           VERSION_CODE=$((START_VERSION_OFFSET + NUM_OF_COMMITS))
           echo "#vc $VERSION_CODE"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -33,14 +33,13 @@ jobs:
     steps:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XC_VERSION.app"
-        if: false
 
       - uses: actions/checkout@v2
 
       # CCache
       - name: Prepare build cache for pull request
         uses: pat-s/always-upload-cache@v2.1.5
-        if: false
+        if: github.event_name == 'pull_request'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: build-ios-ccache-${{ github.actor }}-${{ github.head_ref }}-${{ github.sha }}
@@ -54,7 +53,7 @@ jobs:
       - name: Prepare build cache for branch/tag
         # use a fork of actions/cache@v2 to upload cache even when the build or test failed
         uses: pat-s/always-upload-cache@v2.1.5
-        if: false
+        if: github.event_name != 'pull_request'
         with:
           path: ${{ env.CCACHE_DIR }}
           # The branch or tag ref that triggered the workflow run. For branches this in the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>
@@ -64,7 +63,6 @@ jobs:
             build-ios-ccache-refs/heads/master-
 
       - name: Install brew deps
-        if: false
         run: |
           brew install gnupg
           brew install openssl@1.1
@@ -72,14 +70,12 @@ jobs:
           brew install ccache
 
       - name: Install ccache
-        if: false
         run: |
           mkdir -p ${CCACHE_DIR}
           ccache --set-config=max_size=2.0G
           ccache -s
 
       - name: Extract Mergin API_KEY
-        if: false
         env:
           MERGINSECRETS_DECRYPT_KEY: ${{ secrets.MERGINSECRETS_DECRYPT_KEY }}
         run: |
@@ -92,7 +88,6 @@ jobs:
               -md md5
 
       - name: Configure Keychain
-        if: false
         run: |
           security create-keychain -p "" "$KEYCHAIN"
           security list-keychains -s "$KEYCHAIN"
@@ -102,7 +97,6 @@ jobs:
           security list-keychains
 
       - name: Configure Code Signing
-        if: false
         env:
           IOS_GPG_KEY: ${{ secrets.IOS_GPG_KEY }}
           IOS_CERT_KEY: ${{ secrets.IOS_CERT_KEY }}
@@ -117,7 +111,6 @@ jobs:
 
       # Input SDK
       - name: Cache Input-SDK
-        if: false
         id: cache-input-sdk
         uses: pat-s/always-upload-cache@v2.1.5
         with:
@@ -125,7 +118,7 @@ jobs:
           key: ${{ runner.os }}-input-sdk-v1-${{ env.INPUT_SDK_VERSION }}-${{ env.CACHE_VERSION }}
 
       - name: Install Input-SDK
-        if: false
+        if: steps.cache-input-sdk.outputs.cache-hit != 'true'
         run: |
           wget -O \
             ${{ github.workspace }}/input-sdk.tar.gz \
@@ -138,14 +131,12 @@ jobs:
       - name: Cache Qt
         id: cache-qt
         uses: pat-s/always-upload-cache@v2.1.5
-        if: false
         with:
           path: ${{ github.workspace }}/Qt
           key: ${{ runner.os }}-QtCache-v1-${{ env.QT_VERSION }}-ios-${{ env.CACHE_VERSION }}
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
-        if: false
         with:
           version: ${{ env.QT_VERSION }}
           target: ios
@@ -157,7 +148,6 @@ jobs:
       # Do this only until we move from 5.14.2!!
       - name: Patch Qt!
         shell: bash
-        if: false
         run: |
           echo "Patch 5.14.2 see https://github.com/MerginMaps/input-sdk/issues/34"
 
@@ -175,7 +165,6 @@ jobs:
       # !! and ccache received all of the compilation flags that were supposed to go to clang.
       - name: Export app/config.pri
         shell: bash
-        if: false
         run: |
           touch ./app/config.pri
           echo -e "ios {"  >> ./app/config.pri
@@ -193,7 +182,7 @@ jobs:
             exit 1
           fi
 
-      - name: Calculate build number
+      - name: Calculate a build number
         env:
           OFFFSET: 10 # offset for build number - due to previous builds ~ new builds must always have a higher number
         run: |
@@ -206,7 +195,7 @@ jobs:
 
             echo "Build number: ${CF_BUNDLE_VERSION}"
 
-      - name: Create build system with 
+      - name: Create build system with qmake
         run: |
           INPUT_DIR=`pwd`
 
@@ -219,33 +208,32 @@ jobs:
           mkdir -p build-INPUT
           cd build-INPUT
 
-          # run qmake
-          # ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/bin/qmake \
-          #   ${INPUT_DIR}/app/input.pro \
-          #   -spec macx-ios-clang \
-          #   CONFIG+=release \
-          #   CONFIG+=iphoneos \
-          #   CONFIG+=device \
-          #   CONFIG+=qtquickcompiler \
-          #   QMAKE_MAC_XCODE_SETTINGS+=qprofile \
-          #   qprofile.name=PROVISIONING_PROFILE_SPECIFIER \
-          #   qprofile.value="LutraConsultingLtd.Input.AppStore" \
-          #   QMAKE_MAC_XCODE_SETTINGS+=qteam \
-          #   qteam.name=DEVELOPMENT_TEAM \
-          #   qteam.value=79QMH2QRAH \
-          #   QMAKE_MAC_XCODE_SETTINGS+=qidentity \
-          #   qidentity.name=CODE_SIGN_IDENTITY \
-          #   qidentity.value="iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)" \
-          #   QMAKE_MAC_XCODE_SETTINGS+=qstyle \
-          #   qstyle.name=CODE_SIGN_STYLE \
-          #   qstyle.value=Manual
+          run qmake
+          ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/bin/qmake \
+            ${INPUT_DIR}/app/input.pro \
+            -spec macx-ios-clang \
+            CONFIG+=release \
+            CONFIG+=iphoneos \
+            CONFIG+=device \
+            CONFIG+=qtquickcompiler \
+            QMAKE_MAC_XCODE_SETTINGS+=qprofile \
+            qprofile.name=PROVISIONING_PROFILE_SPECIFIER \
+            qprofile.value="LutraConsultingLtd.Input.AppStore" \
+            QMAKE_MAC_XCODE_SETTINGS+=qteam \
+            qteam.name=DEVELOPMENT_TEAM \
+            qteam.value=79QMH2QRAH \
+            QMAKE_MAC_XCODE_SETTINGS+=qidentity \
+            qidentity.name=CODE_SIGN_IDENTITY \
+            qidentity.value="iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)" \
+            QMAKE_MAC_XCODE_SETTINGS+=qstyle \
+            qstyle.name=CODE_SIGN_STYLE \
+            qstyle.value=Manual
             
-          # # Use old deprecated build system in XCode 13
-          # /usr/libexec/PlistBuddy -c "Add :DisableBuildSystemDeprecationDiagnostic bool" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
-          # /usr/libexec/PlistBuddy -c "Set :DisableBuildSystemDeprecationDiagnostic true" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+          # Use old deprecated build system in XCode 13
+          /usr/libexec/PlistBuddy -c "Add :DisableBuildSystemDeprecationDiagnostic bool" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+          /usr/libexec/PlistBuddy -c "Set :DisableBuildSystemDeprecationDiagnostic true" ./Input.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
               
       - name: Build Input
-        if: false
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
@@ -259,7 +247,6 @@ jobs:
             "OTHER_CODE_SIGN_FLAGS=--keychain '$KEYCHAIN'"
 
       - name: Create Input Package
-        if: false
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
@@ -275,7 +262,7 @@ jobs:
           INPUTAPP_BOT_APPLEID_PASS: ${{ secrets.INPUTAPP_BOT_APPLEID_PASS }}
           INPUTAPP_BOT_APPLEID_USER: ${{ secrets.INPUTAPP_BOT_APPLEID_USER }}
           INPUTAPP_BOT_GITHUB_TOKEN: ${{ secrets.INPUTAPP_BOT_GITHUB_TOKEN }}
-        if: false
+        if: success()
         run: |
           CF_BUNDLE_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" app/ios/Info.plist`
           echo "Publishing ios ${CF_BUNDLE_VERSION}"


### PR DESCRIPTION
CI/CD version codes used `git rev-list` to come up with build numbers. This is not a good way of doing it due to force pushes, squashing and rebasing... iOS then often failed with duplicated/smaller versions being uploaded than are already on the testflight.

We now use GITHUB_ACTION_NUMBER and GITHUB_ACTION_ATTEMPT to determine the build number. This way it should be prone to any git operations and manual rerun of workflows.

PR also renames Android artefacts from out-release-signed.apk to something more meaningful :)