### PR TITLE
Fix ui for Qt6 and manifest parse error

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -47,7 +47,7 @@
                 * minimal - useful for Quick Controls 2 apps, it is much faster than "full"
                 * none - useful for apps that don't use any of the above Qt modules
                 -->
-            <meta-data android:name="android.app.extract_android_style" android:value="default"/>
+            <meta-data android:name="android.app.extract_android_style" android:value="minimal"/>
             <!-- extract android style -->
         </activity>
 

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -21,7 +21,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
             <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
-            <!-- <meta-data android:name="android.app.arguments" android:value="-- %%INSERT_APP_ARGUMENTS%% --" /> -->
+            <!-- <meta-data android:name="android.app.arguments" android:value="-\- %%INSERT_APP_ARGUMENTS%% -\-" /> -->
 
             <!-- Splash screen -->
             <meta-data android:name="android.app.splash_screen_drawable" android:resource="@drawable/splashscreen"/>

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -1,1 +1,2 @@
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4608m

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -113,6 +113,8 @@
 #include "layer/layerdetaildata.h"
 #include "layer/layerdetaillegendimageprovider.h"
 
+#include <QQuickStyle>
+
 #ifndef NDEBUG
 // #include <QQmlDebuggingEnabler>
 #endif
@@ -566,6 +568,7 @@ int main( int argc, char *argv[] )
   }
   app.setFont( QFont( "Lato" ) );
 
+  QQuickStyle::setStyle( "Basic" );
   QQmlEngine engine;
   addQmlImportPath( engine );
   initDeclarative();


### PR DESCRIPTION
PR sets default Qt quick theme back to `Basic`, resulting in our previous style.

PR also fixes an issue when `AndroidManifest.xml` could not be parsed by Qt Creator