### PR TITLE
Disable native heap pointer tagging - fix Android color errors

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -9,6 +9,7 @@
                  android:label="Mergin Maps"
                  android:icon="@mipmap/ic_merginmaps_launcher"
                  android:extractNativeLibs="true"
+                 android:allowNativeHeapPointerTagging="false"
                  android:preserveLegacyExternalStorage="true">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
                   android:name="uk.co.lutraconsulting.InputActivity"


### PR DESCRIPTION
For future reference and if someone comes along fighting errors like `QColor::fromRgbF: Alpha parameter out of range`  - set `android:allowNativeHeapPointerTagging="false"` in the `application` tag in `AndroidManifest.xml`.

It made the app unable to parse hex colour strings and simple colour names like "red" and others.

Qt Qt6 colour issue

See https://bugreports.qt.io/browse/QTBUG-97009
See https://github.com/qt/qtbase/commit/54576b3dd9990a62434cfb805b2f9158e3eaf8c4
See https://source.android.com/docs/security/test/tagged-pointers
