### PR TITLE
Replace unavailable qt5 shortcuts with standard paths in qt6 ~ fix opening of feature form

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -56,6 +56,7 @@
 #include <limits>
 #include <math.h>
 #include <iostream>
+#include <QStandardPaths>
 
 static const QString DATE_TIME_FORMAT = QStringLiteral( "yyMMdd-hhmmss" );
 static const QString INVALID_DATETIME_STR = QStringLiteral( "Invalid datetime" );
@@ -1969,4 +1970,9 @@ void InputUtils::updateFeature( const FeatureLayerPair &pair )
   pair.layer()->updateFeature( f );
   pair.layer()->commitChanges();
   pair.layer()->triggerRepaint();
+}
+
+QString InputUtils::imageGalleryLocation()
+{
+  return QStandardPaths::standardLocations( QStandardPaths::PicturesLocation ).last();
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1974,5 +1974,13 @@ void InputUtils::updateFeature( const FeatureLayerPair &pair )
 
 QString InputUtils::imageGalleryLocation()
 {
-  return QStandardPaths::standardLocations( QStandardPaths::PicturesLocation ).last();
+  QStringList galleryPaths = QStandardPaths::standardLocations( QStandardPaths::PicturesLocation );
+
+  if ( galleryPaths.isEmpty() )
+  {
+    CoreUtils::log( QStringLiteral( "Image Picker" ), QStringLiteral( "Could not find standard path to image gallery" ) );
+    return QString();
+  }
+
+  return galleryPaths.last();
 }

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -509,6 +509,9 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static void updateFeature( const FeatureLayerPair &pair );
 
+    // Returns default path to images in this system
+    Q_INVOKABLE static QString imageGalleryLocation();
+
 
   signals:
     Q_INVOKABLE void showNotificationRequested( const QString &message );

--- a/app/qml/ExternalResourceBundle.qml
+++ b/app/qml/ExternalResourceBundle.qml
@@ -207,7 +207,7 @@ Item {
         nameFilters: [ qsTr( "Image files (*.gif *.png *.jpg)" ) ]
         //width: window.width
         //height: window.height
-        currentFolder: shortcuts.pictures // https://doc.qt.io/qt-5/ios-platform-notes.html#native-image-picker
+        currentFolder: __inputUtils.imageGalleryLocation()
         onAccepted: externalResourceHandler.imageSelected(fileDialog.fileUrl)
     }
 


### PR DESCRIPTION
Fixes opening of feature form.
`shortcuts.pictures` was a Qt5 way to get a path to the gallery on different platforms. `QStandardPaths` is a way to do it in C++.

Note: it is used only on macOS/Linux/Windows, iOS and Android have a native implementation. Unfortunately, this code runs each time form is opened no matter the platform.