### PR TITLE
Upgrade AndroidManifest and build.gradle files based on Qt6.3.2 version

### DIFF
--- a/app/android.pri
+++ b/app/android.pri
@@ -34,6 +34,10 @@ android {
     INCLUDEPATH += $${INPUT_SDK_INCLUDE_PATH}
     INCLUDEPATH += $${INPUT_SDK_INCLUDE_PATH}/qgis
 
+    # see https://source.android.com/docs/setup/about/build-numbers#platform-code-names-versions-api-levels-and-ndk-releases
+    ANDROID_TARGET_SDK_VERSION = 31
+    ANDROID_MIN_SDK_VERSION = 24
+
     # by default QMake eats linked libs if they are mentioned multiple times
     # https://stackoverflow.com/questions/18327959/qmake-how-to-link-a-library-twice/18328971
     CONFIG += no_lflags_merge

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="uk.co.lutraconsulting"
     android:installLocation="auto"
-    android:versionCode="-- %%INSERT_VERSION_CODE%% --"
-    android:versionName="-- %%INSERT_VERSION_NAME%% --">
+    android:versionCode="__BASH_REPLACE_CODE__"
+    android:versionName="__BASH_REPLACE_VERSION__">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/> <!-- Need due to a legacy storage migration -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -1,32 +1,72 @@
-<?xml version='1.0' encoding='utf-8'?>
-<manifest package="uk.co.lutraconsulting"
-          xmlns:android="http://schemas.android.com/apk/res/android"
-          android:versionName="__BASH_REPLACE_VERSION__"
-          android:versionCode="__BASH_REPLACE_CODE__"
-          android:installLocation="auto">
-    <application android:hardwareAccelerated="true"
-                 android:name="org.qtproject.qt.android.bindings.QtApplication"
-                 android:label="Mergin Maps"
-                 android:icon="@mipmap/ic_merginmaps_launcher"
-                 android:extractNativeLibs="true"
-                 android:allowNativeHeapPointerTagging="false"
-                 android:preserveLegacyExternalStorage="true">
-        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
-                  android:name="uk.co.lutraconsulting.InputActivity"
-                  android:label="Mergin Maps"
-                  android:screenOrientation="unspecified"
-                  android:launchMode="singleTop"
-                  android:theme="@style/SplashScreenTheme">
+<?xml version="1.0"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="uk.co.lutraconsulting"
+    android:installLocation="auto"
+    android:versionCode="-- %%INSERT_VERSION_CODE%% --"
+    android:versionName="-- %%INSERT_VERSION_NAME%% --">
+
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/> <!-- Need due to a legacy storage migration -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/> <!-- Reading compass while taking a picture -->
+
+    <!-- Android considers EXIF data as sensitive (since they contain user's location), so we need to opt for permission ACCESS_MEDIA_LOCATION.
+    Even though it is a runtime permission (one need to opt for it in code),
+    it has no GUI element (is granted automatically without user's input, user do not see anything). -->
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
+
+    <!-- %%INSERT_FEATURES -->
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
+    <uses-feature android:name="android.hardware.camera.any" android:required="false"/>
+
+    <supports-screens
+        android:anyDensity="true"
+        android:largeScreens="true"
+        android:normalScreens="true"
+        android:smallScreens="true" />
+    <!-- "preserveLegacyExternalStorage" is needed to support legacy storage migration -->
+    <!-- "allowBackup" is suspicious, see https://developer.android.com/guide/topics/manifest/application-element#allowbackup -->
+    <application 
+        android:name="org.qtproject.qt.android.bindings.QtApplication"
+        android:hardwareAccelerated="true"
+        android:label="Mergin Maps"
+        android:preserveLegacyExternalStorage="true" 
+        android:allowNativeHeapPointerTagging="false"
+        android:allowBackup="true"
+        android:fullBackupOnly="false"
+        android:icon="@mipmap/ic_merginmaps_launcher">
+        <activity
+            android:name="uk.co.lutraconsulting.InputActivity"
+            android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
+            android:label="Mergin Maps"
+            android:launchMode="singleTop"
+            android:screenOrientation="unspecified"
+            android:exported="true"
+            android:theme="@style/SplashScreenTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
-            <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
-            <!-- <meta-data android:name="android.app.arguments" android:value="-\- %%INSERT_APP_ARGUMENTS%% -\-" /> -->
+
+            <meta-data 
+                android:name="android.app.lib_name" 
+                android:value="-- %%INSERT_APP_LIB_NAME%% --" />
+
+            <meta-data 
+                android:name="android.app.arguments" 
+                android:value="-- %%INSERT_APP_ARGUMENTS%% --" />
 
             <!-- Splash screen -->
-            <meta-data android:name="android.app.splash_screen_drawable" android:resource="@drawable/splashscreen"/>
-            <meta-data android:name="android.app.splash_screen_sticky" android:value="true"/>
+            <meta-data 
+                android:name="android.app.splash_screen_drawable" 
+                android:resource="@drawable/splashscreen" />
+            <meta-data 
+                android:name="android.app.splash_screen_sticky" 
+                android:value="true" />
             <!-- Splash screen -->
 
             <!-- Background running -->
@@ -48,7 +88,9 @@
                 * minimal - useful for Quick Controls 2 apps, it is much faster than "full"
                 * none - useful for apps that don't use any of the above Qt modules
                 -->
-            <meta-data android:name="android.app.extract_android_style" android:value="minimal"/>
+            <meta-data 
+                android:name="android.app.extract_android_style" 
+                android:value="minimal" />
             <!-- extract android style -->
         </activity>
 
@@ -64,46 +106,6 @@
         </provider>
 
     </application>
-    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
-    <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
-
-    <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
-         Remove the comment if you do not require these default permissions. -->
-    <!-- <insert double percentage signs to automatically insert permissions from Qt>INSERT_PERMISSIONS -->
-
-    <!-- Storage permissions -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/> <!-- Will be replaced to READ after legacy folder migration -->
-
-    <!-- Access internet permissions -->
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-
-    <!-- Location permissions -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-
-    <!-- Bluetooth permissions -->
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
-
-    <!-- Android considers EXIF data as sensitive (since they contain user's location), so we need to opt for permission ACCESS_MEDIA_LOCATION.
-    Even though it is a runtime permission (one need to opt for it in code),
-    it has no GUI element (is granted automatically without user's input, user do not see anything). -->
-    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
-
-    <!-- Camera permissions -->
-    <uses-permission android:name="android.permission.CAMERA"/>
-
-    <!-- Add the following permission when app should target Android 12 (API LVL 31), it is used for orientation sensor! -->
-    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>
-
-    <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
-         Remove the comment if you do not require these default features. -->
-    <!-- %%INSERT_FEATURES -->
-
-    <!-- Bluetooth feature - our app can run even without bluetooth -->
-    <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
-
-    <uses-feature android:name="android.hardware.camera.any" android:required="false"/>
 
     <!-- Explicitly mention that we need to use external app for capturing an image -->
     <queries>

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -77,10 +77,6 @@
             <meta-data android:name="android.app.background_running" android:value="false"/>
             <!-- Background running -->
 
-            <!-- auto screen scale factor -->
-            <meta-data android:name="android.app.auto_screen_scale_factor" android:value="false"/>
-            <!-- auto screen scale factor -->
-
             <!-- extract android style -->
             <!-- available android:values :
                 * default - In most cases this will be the same as "full", but it can also be something else if needed, e.g., for compatibility reasons

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -13,7 +13,7 @@ buildscript {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 apply plugin: 'com.android.application'
@@ -59,6 +59,10 @@ android {
        }
     }
 
+    tasks.withType(JavaCompile) {
+        options.incremental = true
+    }
+
     compileOptions {
     	sourceCompatibility JavaVersion.VERSION_1_8
 	    targetCompatibility JavaVersion.VERSION_1_8
@@ -79,5 +83,4 @@ android {
         targetSdkVersion qtTargetSdkVersion
         ndk.abiFilters = qtTargetAbiList.split(",")
     }
-
 }

--- a/scripts/android-apk.bash
+++ b/scripts/android-apk.bash
@@ -5,9 +5,10 @@
 # QT_NATIVE_BASE, e.g. /opt/Qt/<version>/macos
 # SOURCE_DIR, path to input root source dir
 # ANDROID_NDK_ROOT, e.g. /opt/Android/sdk/ndk/<version>
-# ANDROID_NDK_HOST, e.g. darwin_x86_64 (on mac)
+# ANDROID_NDK_HOST, e.g. darwin-x86_64 (on mac)
 # ANDROID_NDK_PLATFORM=android-24
 # ANDROIDAPI=24
+# SDK_PLATFORM=android-31
 # ARCH=armeabi-v7a or arm640v8a
 # INPUTKEYSTORE_STOREPASS
 # make sure you have JAVA_HOME env set to your java installation where JAVA_HOME/lib/tools.jar exists


### PR DESCRIPTION
`AndroidManifest.xml` and `build.gradle` are now aligned with Qt 6.3.2 version of these files.

Things that has changed:
 - `AndroidManifest.xml`:
   - added:
      - `android:allowBackup="true"` (see https://github.com/qt/qtbase/commit/56dee3de5e4ac1c4d37a2c5e27361e7ddbdea1a7)
      -  `android:fullBackupOnly="false" ` (see https://github.com/qt/qtbase/commit/56dee3de5e4ac1c4d37a2c5e27361e7ddbdea1a7)
      -  `android.app.arguments` <-- uncommented
   - removed:
     - `uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"` - setting minSdk and targetSdk has been moved to build.gradle file (see https://github.com/qt/qtbase/commit/519ea72108fae7f5c4ed7c3e9fed3a999a16ed73#diff-790ad42137a254b3eaddfe7fc2d7e0722ca055ebeec76a0beeab7a0bcf87e074)
     - `android:extractNativeLibs="true"` - moved to build.gradle (see https://github.com/qt/qtbase/commit/3a9aba287ce92f5250c1b68d0e2a39a5f25c031d)
     - `android.app.auto_screen_scale_factor` - is now on by default (see https://github.com/qt/qtbase/commit/233b6534a79c09e30b9aeb14dbb1cb469a67f2a0)
 - `build.gradle`:
    - added:
       - `JavaCompile -> options.incremental = true` - faster java builds (see https://github.com/qt/qtbase/commit/615b92008a7e6673bc74ec6e971a6bca5f5c81f6#diff-790ad42137a254b3eaddfe7fc2d7e0722ca055ebeec76a0beeab7a0bcf87e074)  
    - changed:
       - deprecated `jcenter` replaced by `mavenCentral` (see https://github.com/qt/qtbase/commit/3dbca82f861c8c83eea32560d5e63e1c71057d3b)
