### PR TITLE
New BT permissions for Android 12 and allocation limit for photos

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -9,8 +9,10 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" /> <!-- BT permission up to SDK 30-->
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" /> <!-- BT permission up to SDK 30-->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/> <!-- Reading compass while taking a picture -->
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -19,6 +19,7 @@
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QLocale>
+#include <QImageReader>
 #ifdef INPUT_TEST
 #include "test/inputtests.h"
 #endif
@@ -709,6 +710,9 @@ int main( int argc, char *argv[] )
 
   // save app version to settings
   as.setAppVersion( version );
+
+  // Photos bigger that 512 MB (when uncompressed) will not load
+  QImageReader::setAllocationLimit( 512 );
 
   int ret = EXIT_FAILURE;
   try


### PR DESCRIPTION
BT permissions changed in Android 12, see https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#declare-android12-or-higher 
Legacy BT permissions are set to affect only up to Android 11, new permissions from Android 12 on.

The default allocation limit for uncompressed photos was not big enough to show photos taken with >30 megapixels cameras (128 MB). Images taken with such a camera were not loaded in the image preview.

Resolves #2385 
Resolves #2388 