### PR TITLE
Do not wrap define value in string

### DIFF
--- a/app/bluetoothdiscoverymodel.cpp
+++ b/app/bluetoothdiscoverymodel.cpp
@@ -27,7 +27,7 @@ BluetoothDiscoveryModel::BluetoothDiscoveryModel( QObject *parent ) : QAbstractL
 
   connect( mDiscoveryAgent.get(), &QBluetoothDeviceDiscoveryAgent::errorOccurred, this, [ = ]( QBluetoothDeviceDiscoveryAgent::Error error )
   {
-    CoreUtils::log( "Bluetooth discovery", QString( "Error occured during device discovery, error code #" ).arg( error ) );
+    CoreUtils::log( "Bluetooth discovery", QString( "Error occured during device discovery, error code #%1" ).arg( error ) );
     finishedDiscovery();
   } );
 #endif

--- a/cmake_templates/inputconfig.h.in
+++ b/cmake_templates/inputconfig.h.in
@@ -4,9 +4,9 @@
 #define INPUT_APP
 
 #cmakedefine VERSTR "@ESCAPED_VERSTR@"
-#cmakedefine INPUT_VERSION "@INPUT_VERSION@"
+#cmakedefine INPUT_VERSION @INPUT_VERSION@
 
-#cmakedefine QGIS_QUICK_DATA_PATH "@QGIS_QUICK_DATA_PATH@"
+#cmakedefine QGIS_QUICK_DATA_PATH @QGIS_QUICK_DATA_PATH@
 
 #cmakedefine INPUT_TEST
 #cmakedefine TEST_DATA_DIR "@TEST_DATA_DIR@"


### PR DESCRIPTION
QGIS_QUICK_DATA_PATH resulted in ""\<path\>"" (note the double quotes) - MM could not read it then, it read something like "\\"\<path\>\\""

Therefore, assets could not be read.