### PR TITLE
Qt6 fixes/Range editor fixes

### DIFF
--- a/app/qml/editor/AbstractEditor.qml
+++ b/app/qml/editor/AbstractEditor.qml
@@ -55,11 +55,18 @@ Item {
       height: parent.height
       width: actionAllowed ? parent.height : 0
 
-      MouseArea {
+      Item {
         width: leftActionContainer.actionAllowed ? parent.width + customStyle.fields.sideMargin : parent.width
         x: leftActionContainer.actionAllowed ? parent.x - customStyle.fields.sideMargin : parent.x
         height: parent.height
-        onClicked: root.leftActionClicked()
+
+        TapHandler {
+          onPressedChanged: {
+            if ( !pressed ) {
+              root.leftActionClicked()
+            }
+          }
+        }
       }
     }
 
@@ -72,10 +79,12 @@ Item {
       height: parent.height
       width: parent.width - ( leftActionContainer.width + rightActionContainer.width )
 
-      MouseArea {
-        width: parent.width
-        height: parent.height
-        onClicked: root.contentClicked()
+      TapHandler {
+        onPressedChanged: {
+          if ( !pressed ) {
+            root.contentClicked()
+          }
+        }
       }
     }
 
@@ -90,10 +99,17 @@ Item {
       height: parent.height
       width: actionAllowed > 0 ? parent.height : 0
 
-      MouseArea {
+      Item {
         width: rightActionContainer.actionAllowed ? parent.width + customStyle.fields.sideMargin : parent.width
         height: parent.height
-        onClicked: root.rightActionClicked()
+
+        TapHandler {
+          onPressedChanged: {
+            if ( !pressed ) {
+              root.rightActionClicked()
+            }
+          }
+        }
       }
     }
   }

--- a/app/qml/form/FeatureForm.qml
+++ b/app/qml/form/FeatureForm.qml
@@ -296,6 +296,11 @@ Item {
     SwipeView {
       id: swipeView
       currentIndex: form.controller.hasTabs ? tabRow.currentIndex : 0
+
+      //
+      // Known limitation, we can not make swipeview interactive because of https://bugreports.qt.io/browse/QTBUG-109124
+      // It clashes with slider editors, see https://github.com/MerginMaps/input/issues/2411
+      //
       interactive: false
 
       anchors {

--- a/app/qml/form/FeatureForm.qml
+++ b/app/qml/form/FeatureForm.qml
@@ -296,6 +296,8 @@ Item {
     SwipeView {
       id: swipeView
       currentIndex: form.controller.hasTabs ? tabRow.currentIndex : 0
+      interactive: false
+
       anchors {
         top: flickable.bottom
         left: container.left


### PR DESCRIPTION
### Range editor

Replaces `MouseArea` in `AbstractEditor`(base class to refactored editors) with `TapHandlers` that receive clicks all the time.

>Note: The reason why `MouseArea` stops listening to clicks after double-clicking in this scenario remains secret.

### Range slider editor

Due to a Qt bug https://bugreports.qt.io/browse/QTBUG-109124 `SwipeView` steals grab on `Slider`'s handle which results in page swap instead of handle movement.
Fixed by making the `SwipeView` not interactive.

---

Fixes #2411 

#326m313