### PR TITLE
Qt6 fixes/Do not propagate clicks to canvas when not using map

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -160,6 +160,9 @@ ApplicationWindow {
         }
         else if ( stateManager.state === "projects" || stateManager.state === "misc" )
         {
+          //
+          // Due to an upstream bug in Qt, see #2387 and #2425 for more info
+          //
           return window.height
         }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -158,6 +158,11 @@ ApplicationWindow {
           // if feature preview panel is opened
           return formsStackManager.takenVerticalSpace - mainPanel.height
         }
+        else if ( stateManager.state === "projects" || stateManager.state === "misc" )
+        {
+          return window.height
+        }
+
         return 0
       }
 


### PR DESCRIPTION
Enlarging the scope of the workaround for auto-closing form.
See more details at https://github.com/MerginMaps/input/pull/2387

We now block clicks (change size of TapHandler's area to 0) when something else than the map is visible.

Fixes #2409 
#326m37b