### PR TITLE
Qt6 fixes/Fix back button in layers list

### DIFF
--- a/app/qml/form/FeatureFormPage.qml
+++ b/app/qml/form/FeatureFormPage.qml
@@ -27,11 +27,16 @@ Item {
   property string formState
 
   signal close()
+  signal opened()
   signal editGeometryClicked( var pair )
   signal splitGeometryClicked()
   signal redrawGeometryClicked( var pair )
   signal openLinkedFeature( var linkedFeature )
   signal createLinkedFeature( var parentController, var relation )
+
+  onOpened: {
+    formStackView.forceActiveFocus()
+  }
 
   StackView {
     id: formStackView

--- a/app/qml/form/FormWrapper.qml
+++ b/app/qml/form/FormWrapper.qml
@@ -73,6 +73,11 @@ Item {
           PropertyChanges { target: drawer; interactive: false }
           PropertyChanges { target: formContainer; visible: true }
           PropertyChanges { target: previewPanel; visible: false }
+          StateChangeScript {
+            script: {
+              formContainer.opened()
+            }
+          }
         },
         State {
           name: "closed"

--- a/app/qml/layers/LayersPanelV2.qml
+++ b/app/qml/layers/LayersPanelV2.qml
@@ -49,7 +49,13 @@ Item {
   Keys.onReleased: function( event ) {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       event.accepted = true
-      root.close()
+
+      if ( pagesStackView.depth === 1 ) {
+        root.close()
+      }
+      else {
+        pagesStackView.pop( StackView.PopTransition )
+      }
     }
   }
 


### PR DESCRIPTION
Includes 2 fixes:
  1. back button now closes only the topmost page in the layer's list, not the entire layers' panel
  2. the topmost form receives an active focus when opened

Fixes #2407 
#326m3dk