### PR TITLE
Fix value relation widget that was sometimes missing labels

### DIFF
--- a/app/qml/editor/inputvaluerelationpage.qml
+++ b/app/qml/editor/inputvaluerelationpage.qml
@@ -92,7 +92,7 @@ AbstractEditor {
     anchors.leftMargin: customStyle.fields.sideMargin
     color: customStyle.fields.fontColor
     font.pixelSize: customStyle.fields.fontPixelSize
-    clip: true
+    elide: Text.ElideRight
 
     horizontalAlignment: Text.AlignLeft
     verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
Fixes #2412

It turns out everything was working fine under the hood, it was just that the text of the widget was not appearing properly.

It looks like there is a Qt bug (at least as of Qt 6.4.1) in Text/Label item that will keep the item off the screen even if it was meant to render, in conditions like this:
- clipping is enabled
- the text is initially empty
- the text gets changed while the item is hidden, only then in gets visible

In any case, we should be using elide rather than clipping for text items, and that fixes the issue with visibility as well.