### PR TITLE
Qt6 fixes/Fix focus in forms

### DIFF
--- a/app/qml/AuthPanel.qml
+++ b/app/qml/AuthPanel.qml
@@ -112,7 +112,7 @@ Item {
     RegistrationForm {
       id: registrationForm
       visible: false
-      height: Qt.inputMethod.visible ? parent.height + staticPane.height - Qt.inputMethod.keyboardRectangle.height : parent.height - staticPane.height
+      height: parent.height - staticPane.height
       width: parent.width
     }
 

--- a/app/qml/editor/AbstractEditor.qml
+++ b/app/qml/editor/AbstractEditor.qml
@@ -80,10 +80,8 @@ Item {
       width: parent.width - ( leftActionContainer.width + rightActionContainer.width )
 
       TapHandler {
-        onPressedChanged: {
-          if ( !pressed ) {
-            root.contentClicked()
-          }
+        onSingleTapped: {
+          root.contentClicked()
         }
       }
     }

--- a/app/qml/editor/inputrangeeditable.qml
+++ b/app/qml/editor/inputrangeeditable.qml
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -76,12 +76,14 @@ AbstractEditor {
 
       x: parent.width / 2 - width / 2
 
-      width: numberInput.contentWidth + suffix.contentWidth > parent.width ? parent.width : numberInput.contentWidth + suffix.contentWidth
+      width: childrenRect.width
 
       height: parent.height
 
       TextInput {
         id: numberInput
+
+        property real maxWidth: contentContainer.width - suffix.width
 
         onTextEdited: {
           let val = text.replace( ",", "." ).replace( / /g, '' ) // replace comma with dot
@@ -91,7 +93,18 @@ AbstractEditor {
         text: root.parentValue === undefined || root.parentValueIsNull ? "" : root.parentValue
 
         height: parent.height
-        width: contentWidth < ( parent.width - suffix.width ) ? contentWidth : parent.width - suffix.width
+        width: {
+          // set parent width if the number exceeds width of the field
+          if ( contentWidth > numberInput.maxWidth ) {
+            return numberInput.maxWidth
+          }
+
+          if ( contentWidth > 0 ) {
+            return contentWidth
+          }
+
+          return 1 // TextInput must have width set at least to one, otherwise listview would not scroll to this element
+        }
 
         inputMethodHints: Qt.ImhFormattedNumbersOnly
 
@@ -125,7 +138,12 @@ AbstractEditor {
   }
 
   onContentClicked: {
-    numberInput.forceActiveFocus()
+    if ( numberInput.activeFocus ) {
+      Qt.inputMethod.show() // only show keyboard if we already have active focus
+    }
+    else {
+      numberInput.forceActiveFocus()
+    }
   }
 
   rightAction: Item {


### PR DESCRIPTION
Fixes a few things:
 - Registration form, fixes #2406 
 - Listen to a different signal in `AbstractEditor`, previous `onPressed` were called too many times, worsening the UX of forms
 - Number inputs could end up hidden under the system keyboard in feature form if they were on the end of the form. They had an invalid width set

<img src="https://user-images.githubusercontent.com/22449698/205655066-4c780193-bc04-4fc7-927f-05d13f59b3bc.jpg" width=300>
