### PR TITLE
fix auto tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,8 @@ add_compile_definitions("$<$<CONFIG:DEBUG>:QGIS_QUICK_EXPAND_TEST_DATA>")
 # Generate inputconfig.h
 if (ENABLE_TESTS)
   set(INPUT_TEST TRUE)
-  set(TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test/test_data")
+  file(COPY test/test_data DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/test/)
+  set(TEST_DATA_DIR "${CMAKE_CURRENT_BINARY_DIR}/test/test_data")
 endif ()
 
 if (HAVE_PURCHASING)

--- a/app/test/inputtests.cpp
+++ b/app/test/inputtests.cpp
@@ -80,7 +80,7 @@ QString InputTests::initTestingDir()
 {
   // override the path where local projects are stored
   // and wipe the temporary projects dir if it already exists
-  QDir testDataDir( STR( INPUT_TEST_DATA_DIR ) );  // #defined in input.pro
+  QDir testDataDir( TEST_DATA_DIR );
   QDir testProjectsDir( testDataDir.path() + "/../temp_projects" );
   if ( testProjectsDir.exists() )
     testProjectsDir.removeRecursively();

--- a/app/test/testactiveproject.h
+++ b/app/test/testactiveproject.h
@@ -11,7 +11,6 @@
 #define TESTACTIVEPROJECT_H
 
 #include <QObject>
-#include "inputconfig.h"
 #include <merginapi.h>
 
 class TestActiveProject : public QObject

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -1,9 +1,6 @@
 #include <QtTest/QtTest>
 #include <QtCore/QObject>
 
-#define STR1(x)  #x
-#define STR(x)  STR1(x)
-
 #include "testmerginapi.h"
 #include "inpututils.h"
 #include "coreutils.h"
@@ -67,7 +64,7 @@ void TestMerginApi::initTestCase()
 
   mUsername = username;  // keep for later
 
-  QDir testDataDir( STR( INPUT_TEST_DATA_DIR ) );  // #defined in input.pro
+  QDir testDataDir( TEST_DATA_DIR );
   mTestDataPath = testDataDir.canonicalPath();  // get rid of any ".." that may cause problems later
   qDebug() << "test data dir:" << mTestDataPath;
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2497,25 +2497,31 @@ MerginProjectsList TestMerginApi::getProjectList( QString tag )
 
 MerginProjectsList TestMerginApi::projectListFromSpy( QSignalSpy &spy )
 {
-  QList<QVariant> response = spy.takeFirst();
-
-  // get projects emited from MerginAPI, it is first argument in listProjectsFinished signal
   MerginProjectsList projects;
-  if ( response.length() > 0 )
-    projects = qvariant_cast<MerginProjectsList>( response.at( 0 ) );
 
+  if ( !spy.isEmpty() )
+  {
+    QList<QVariant> response = spy.takeFirst();
+
+    // get projects emited from MerginAPI, it is first argument in listProjectsFinished signal
+    if ( response.length() > 0 )
+      projects = qvariant_cast<MerginProjectsList>( response.at( 0 ) );
+  }
   return projects;
 }
 
 int TestMerginApi::serverVersionFromSpy( QSignalSpy &spy )
 {
-  QList<QVariant> response = spy.takeFirst();
-
-  // get version number emited from MerginApi::syncProjectFinished, it is third argument
   int serverVersion = -1;
-  if ( response.length() >= 4 )
-    serverVersion = response.at( 3 ).toInt();
 
+  if ( !spy.isEmpty() )
+  {
+    QList<QVariant> response = spy.takeFirst();
+
+    // get version number emited from MerginApi::syncProjectFinished, it is third argument
+    if ( response.length() >= 4 )
+      serverVersion = response.at( 3 ).toInt();
+  }
   return serverVersion;
 }
 
@@ -2541,7 +2547,8 @@ void TestMerginApi::createRemoteProject( MerginApi *api, const QString &projectN
   QVERIFY( spy3.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy3.count(), 1 );
   QList<QVariant> arguments = spy3.takeFirst();
-  QVERIFY( arguments.at( 2 ).toBool() );
+  int version = arguments.at( 2 ).toInt();
+  QCOMPARE( version, 1 );
 
   // Remove the whole project
   QDir( projectDir ).removeRecursively();

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -30,6 +30,8 @@
 
 #include <QtTest/QtTest>
 #include <QtCore/QObject>
+#include <QTemporaryDir>
+#include <QLocale>
 
 const int DAY_IN_SECS = 60 * 60 * 24;
 const int MONTH_IN_SECS = 60 * 60 * 24 * 31;
@@ -158,7 +160,11 @@ void TestUtilsFunctions::formatPoint()
 {
   QgsPoint point( -2.234521, 34.4444421 );
   QString point2str =  mUtils->formatPoint( point );
-  QVERIFY( point2str == "-2.235,34.444" );
+  QString expected =
+    QStringLiteral( "-2" ) + QLocale().decimalPoint() + QStringLiteral( "235" )
+    + QgsCoordinateFormatter::separator()
+    + QStringLiteral( "34" ) + QLocale().decimalPoint() + QStringLiteral( "444" );
+  QCOMPARE( point2str, expected );
 }
 
 void TestUtilsFunctions::formatDistance()
@@ -322,8 +328,7 @@ void TestUtilsFunctions::resolveTargetDir()
 void TestUtilsFunctions::testDirSize()
 {
   // create some test data in tmp with non ascii characters
-  QString tempFolder = QDir::tempPath();
-
+  QString tempFolder = QTemporaryDir( QDir::tempPath() + "/input-testDirSize-XXXXXX" ).path();
   QString project = tempFolder + QStringLiteral( "/input-project" );
   qint64 dirSize;
 


### PR DESCRIPTION
- use test_data from build dir
- and fix crashes
- fix autotests - problem was that the INPUT_TEST_DATA_DIR (from qmake) was no longer defined in our cmake build -> we need to use TEST_DATA_DIR from inputconfig.h 