### PR TITLE
Qt6 fixes/Fix swapped BT arguments

### DIFF
--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -323,7 +323,7 @@ Page {
       height: root.height + header.height
       width: root.width
 
-      onInitiatedConnectionTo: function( deviceName, deviceAddress ) {
+      onInitiatedConnectionTo: function( deviceAddress, deviceName ) {
         providersModel.addProvider( deviceName, deviceAddress )
       }
       onClose: root.stackView.pop()
@@ -378,7 +378,7 @@ Page {
           return
         }
 
-        if ( __appSettings.activePositionProviderId == relatedProviderId )
+        if ( __appSettings.activePositionProviderId === relatedProviderId )
         {
           // we are removing an active provider, replace it with internal provider
           root.constructProvider( "internal", "devicegps", qsTr( "Internal" ) )


### PR DESCRIPTION
`deviceAddress` and `deviceName` were simply swapped, which resulted in undefined behaviour 🙂 

#32qr2h2
Fixes #2437 