### PR TITLE
fix second open of broken project

### DIFF
--- a/app/activeproject.cpp
+++ b/app/activeproject.cpp
@@ -158,6 +158,7 @@ bool ActiveProject::forceLoad( const QString &filePath, bool force )
         QList< QgsMapLayer * > layers;
         mMapSettings->setLayers( layers );
       }
+      mQgsProject->clear();
 
       emit localProjectChanged( mLocalProject );
       emit projectReloaded( mQgsProject );


### PR DESCRIPTION
fix #2436 

note: on macOS desktop, if I click outside the window, it stays on the "opening project" and I need to kill the app. not sure why the `MessageDialog` does allow it?

CU-32qr2k9