### PR TITLE
Qt6 fixes/Enable Android signing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -266,7 +266,6 @@ jobs:
           name: APK compined
 
       - name: Upload AAB to Artifacts
-        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/merginmaps-$INPUT_VERSION_CODE.aab

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,8 +32,10 @@ jobs:
       INPUT_SDK_VERSION: android-macOS-20221117-129
       CCACHE_DIR: /Users/runner/work/ccache
       GITHUB_TOKEN: ${{ secrets.INPUTAPP_BOT_GITHUB_TOKEN }}
-      INPUTKEYSTORE_STOREPASS: ${{ secrets.INPUTKEYSTORE_STOREPASS }}
       CACHE_VERSION: 3
+      QT_ANDROID_KEYSTORE_ALIAS: input
+      QT_ANDROID_KEYSTORE_KEY_PASS: ${{ secrets.INPUTKEYSTORE_STOREPASS }}
+      QT_ANDROID_KEYSTORE_STORE_PASS: ${{ secrets.INPUTKEYSTORE_STOREPASS }}
 
     steps:
       - uses: actions/checkout@v3
@@ -182,6 +184,9 @@ jobs:
            -out Input_keystore.keystore \
            -k $INPUTKEYSTORE_DECRYPT_KEY \
            -md md5
+          
+          echo "$$! path to keystore `realpath Input_keystore.keystore`"
+          echo "QT_ANDROID_KEYSTORE_PATH=`realpath Input_keystore.keystore`" >> $GITHUB_ENV
 
       # Build Input App
       - name: Calculate build number
@@ -208,6 +213,8 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DQT_ANDROID_ABIS="arm64-v8a;armeabi-v7a" \
               -DQT_HOST_PATH=$QT_BASE/macos \
+              -DQT_ANDROID_SIGN_APK=Yes \
+              -DQT_ANDROID_SIGN_AAB=Yes \
               -DCMAKE_TOOLCHAIN_FILE=$QT_BASE/android_arm64_v8a/lib/cmake/Qt6/qt.toolchain.cmake \
               -GNinja \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -243,7 +250,7 @@ jobs:
       - name: Rename build artefacts
         run: |
           mv \
-            ${{ github.workspace }}/build-Input/app/android-build/build/outputs/apk/debug/android-build-debug.apk \
+            ${{ github.workspace }}/build-Input/app/android-build/build/outputs/apk/release/android-build-release-signed.apk \
             ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
                        
           mv \
@@ -255,12 +262,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
-          name: arm64 apk
+          name: APK compined
 
       - name: Upload AAB to Artifacts
         if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/merginmaps-$INPUT_VERSION_CODE.aab
-          name: aab bundle
+          name: AAB bundle
           

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -234,8 +234,21 @@ jobs:
             
             echo "APKs:"
             find . | grep .apk
-                
-      - name: build AAB   
+
+      - name: Rename APK artefacts
+        run: |
+          mv \
+            ${{ github.workspace }}/build-Input/app/android-build/build/outputs/apk/release/android-build-release-signed.apk \
+            ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
+
+      - name: Upload APK to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
+          name: APK compined
+
+      - name: build AAB
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         env:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
           ANDROID_NDK_HOST: darwin-x86_64
@@ -247,25 +260,16 @@ jobs:
 
             echo "AAB:"
             find . | grep .aab
-            
-      - name: Rename build artefacts
-        run: |
-          mv \
-            ${{ github.workspace }}/build-Input/app/android-build/build/outputs/apk/release/android-build-release-signed.apk \
-            ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
-                       
+
+      - name: Rename AAB artefacts
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
+        run: |       
           mv \
             ${{ github.workspace }}/build-Input/app/android-build/build/outputs/bundle/release/android-build-release.aab \
             ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.aab
-          
-          
-      - name: Upload APK to Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
-          name: APK compined
 
       - name: Upload AAB to Artifacts
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/merginmaps-$INPUT_VERSION_CODE.aab

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -185,8 +185,9 @@ jobs:
            -k $INPUTKEYSTORE_DECRYPT_KEY \
            -md md5
           
-          echo "$$! path to keystore `realpath Input_keystore.keystore`"
-          echo "QT_ANDROID_KEYSTORE_PATH=`realpath Input_keystore.keystore`" >> $GITHUB_ENV
+          PATH_TO_KEYSTORE=`pwd`/Input_keystore.keystore
+          echo "path to keystore $PATH_TO_KEYSTORE"
+          echo "QT_ANDROID_KEYSTORE_PATH=$PATH_TO_KEYSTORE" >> $GITHUB_ENV
 
       # Build Input App
       - name: Calculate build number

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -272,6 +272,6 @@ jobs:
         if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ github.workspace }}/merginmaps-$INPUT_VERSION_CODE.aab
+          path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.aab
           name: AAB bundle
           


### PR DESCRIPTION
Sign Android CI builds with our upload key. 
Note: We need to sign our builds prior to upload to Google Play otherwise they would be rejected. GP then signs generated APKs with their own distribution key.

4 new env vars must be defined + 2 cmake vars, see more here: https://doc-snapshots.qt.io/qt6-6.4/cmake-variable-qt-android-sign-aab.html