### PR TITLE
Replace TapHandlers on map buttons and in settings panel

### DIFF
--- a/app/qml/NumberSpin.qml
+++ b/app/qml/NumberSpin.qml
@@ -66,22 +66,30 @@ Item {
         rotation: imageIncrease.rotation
     }
 
-//  Mouse areas enlarging clickable areas for arrows, see https://github.com/MerginMaps/input/pull/1055
-    MouseArea {
+//  Click areas enlarging clickable areas for arrows, see https://github.com/MerginMaps/input/pull/1055
+    Item {
       y: imageDecrease.y - imageDecrease.height
       x: imageDecrease.x - imageDecrease.width
       width: imageDecrease.width * 3
       height: imageDecrease.height * 3
 
-      onClicked: if (minValue <= root.value - 1) root.value -=1
+      TapHandler {  
+        onTapped: function(eventPoint, button) {
+            if (minValue <= root.value - 1) root.value -=1
+        }
+      }
     }
 
-    MouseArea {
+    Item {
       y: imageIncrease.y - imageIncrease.height
       x: imageIncrease.x - imageIncrease.width
       width: imageIncrease.width * 3
       height: imageIncrease.height * 3
 
-      onClicked: if (maxValue >= root.value + 1) root.value +=1
+      TapHandler {
+        onTapped: function(eventPoint, button) {
+            if (maxValue >= root.value + 1) root.value +=1
+        }
+      }
     }
 }

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -114,9 +114,10 @@ Item {
               onCheckedChanged: __appSettings.autoCenterMapChecked = checked
             }
 
-            MouseArea {
-              anchors.fill: parent
-              onClicked: autoCenterMapSwitch.toggle()
+            TapHandler {
+              onTapped: function(eventPoint, button) {
+                autoCenterMapSwitch.toggle()
+              }
             }
           }
 
@@ -203,7 +204,7 @@ Item {
           }
 
           PanelItem {
-            height: settingsPanel.rowHeight
+            height: root.rowHeight
             width: parent.width
             text: qsTr("Show accuracy warning")
 
@@ -214,9 +215,10 @@ Item {
               onCheckedChanged: __appSettings.gpsAccuracyWarning = checked
             }
 
-            MouseArea {
-              anchors.fill: parent
-              onClicked: accuracyWarningSwitch.toggle()
+            TapHandler {
+              onTapped: function(eventPoint, button) {
+                accuracyWarningSwitch.toggle()
+              }
             }
           }
 
@@ -274,9 +276,10 @@ Item {
               onCheckedChanged: __appSettings.reuseLastEnteredValues = checked
             }
 
-            MouseArea {
-              anchors.fill: parent
-              onClicked: rememberValuesSwitch.toggle()
+            TapHandler {
+              onTapped: function(eventPoint, button) {
+                rememberValuesSwitch.toggle()
+              }
             }
           }
 
@@ -293,9 +296,10 @@ Item {
               onCheckedChanged: __appSettings.autosyncAllowed = checked
             }
 
-            MouseArea {
-              anchors.fill: parent
-              onClicked: autosyncSwitch.toggle()
+            TapHandler {
+              onTapped: function(eventPoint, button) {
+                autosyncSwitch.toggle()
+              }
             }
           }
 

--- a/app/qml/components/MapFloatButton.qml
+++ b/app/qml/components/MapFloatButton.qml
@@ -47,10 +47,18 @@ Item {
       anchors.horizontalCenter: parent.horizontalCenter
     }
 
-    MouseArea {
+    Item {
       anchors.fill: parent
-      onClicked: root.clicked()
-      onPressAndHold: root.pressAndHold()
+      
+      TapHandler {
+        onTapped: function(eventPoint, button) {
+          root.clicked()
+        }
+
+        onLongPressed: function() {
+          root.pressAndHold()
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Replaces `MouseArea` with `TapHandler` on different places where a user might be tempted to click furiously.