### PR TITLE
Add gps data page to map extent offset [fix stakeout freeze]

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -165,6 +165,14 @@ ApplicationWindow {
           //
           return window.height
         }
+        else if ( gpsDataPageLoader.active )
+        {
+          //
+          // Block also GPS data page clicks propagation.
+          // Due to an upstream bug in Qt, see #2387 and #2425 for more info
+          //
+          return window.height
+        }
 
         return 0
       }
@@ -455,7 +463,6 @@ ApplicationWindow {
             // if we are in stakeout mode
             stakeoutPanelLoader.item.hide()
           }
-          stateManager.state = "misc"
         }
         else
         {
@@ -464,7 +471,6 @@ ApplicationWindow {
             // user closed GPS panel and we are in stakeout mode - reopen stakeout panel
             stakeoutPanelLoader.item.restore()
           }
-          stateManager.state = "map"
         }
       }
     }


### PR DESCRIPTION
Closing GPS data page change map state to view - this is wrong as GPS data page can be opened while recording, staking out, etc. 
In order to not propagate clicks on map canvas, I added the GPS panel to mapExtentOffset. 

Resolves #2438