### PR TITLE
Fix decimal separator in forms

### DIFF
--- a/app/qml/editor/inputrangeeditable.qml
+++ b/app/qml/editor/inputrangeeditable.qml
@@ -87,6 +87,15 @@ AbstractEditor {
 
         onTextEdited: {
           let val = text.replace( ",", "." ).replace( / /g, '' ) // replace comma with dot
+
+          let endsWithDecimalSeparator = val.endsWith('.');
+          let hasOnlyOneDecimalSeparator = val.split('.').length === 2;
+
+          if ( endsWithDecimalSeparator && hasOnlyOneDecimalSeparator )
+          {
+            return; // do not send value changed signal when number ends with decimal separator
+          }
+
           root.editorValueChanged( val, val  === "" )
         }
 

--- a/app/qml/editor/inputtextedit.qml
+++ b/app/qml/editor/inputtextedit.qml
@@ -66,6 +66,14 @@ AbstractEditor {
       if ( field.isNumeric )
       {
         val = val.replace( ",", "." ).replace( / /g, '' ) // replace comma with dot and remove spaces
+
+        let endsWithDecimalSeparator = val.endsWith('.');
+        let hasOnlyOneDecimalSeparator = val.split('.').length === 2;
+
+        if ( endsWithDecimalSeparator && hasOnlyOneDecimalSeparator )
+        {
+          return; // do not send value changed signal when number ends with decimal separator
+        }
       }
 
       editorValueChanged( val, val === "" )


### PR DESCRIPTION
Issue was introduced by https://github.com/MerginMaps/input/commit/2ae5326e907283e14b1fc267575b54a05bfc7f79 

Overall, in order to make #1956 (and similar expression issues) working we needed to start calling `QgsField::convertCompatible` each time value in a field is changed. This brought us here, because for input `123.` `convertCompatible` returns `123` removing the trailing decimal separator. Each decimal separator thus got ignored.

The mentioned commit also introduced another issue - no FieldValidator validation from Mergin Maps, it is more described here https://github.com/MerginMaps/input/issues/2496 and needs a deeper fix.

Fixes #2474 