### PR TITLE
Fix displaying of projects where user is not an author (e.g. was invited)

### DIFF
--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -159,7 +159,7 @@ void ProjectsModel::listProjects( const QString &searchExpression, int page )
     return;
   }
 
-  mLastRequestId = mBackend->listProjects( searchExpression, modelTypeToFlag(), "", page );
+  mLastRequestId = mBackend->listProjects( searchExpression, modelTypeToFlag(), page );
 
   if ( !mLastRequestId.isEmpty() )
   {
@@ -588,6 +588,10 @@ QString ProjectsModel::modelTypeToFlag() const
       return QStringLiteral( "created" );
     case SharedProjectsModel:
       return QStringLiteral( "shared" );
+    case WorkspaceProjectsModel:
+      return QStringLiteral( "workspace" );
+    case PublicProjectsModel:
+      return QStringLiteral( "public" );
     default:
       return QLatin1String();
   }

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -78,6 +78,7 @@ class ProjectsModel : public QAbstractListModel
       CreatedProjectsModel,
       SharedProjectsModel,
       PublicProjectsModel,
+      WorkspaceProjectsModel,
       RecentProjectsModel
     };
     Q_ENUM( ProjectModelTypes )

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -578,7 +578,7 @@ Item {
             localProjectsPage.refreshProjectsList( keepSearchFilter )
             break
           case "created":
-            createdProjectsPage.refreshProjectsList( keepSearchFilter )
+            workspaceProjectsPage.refreshProjectsList( keepSearchFilter )
             break
           case "public":
             publicProjectsPage.refreshProjectsList( keepSearchFilter )
@@ -760,9 +760,9 @@ Item {
           }
 
           ProjectListPage {
-            id: createdProjectsPage
+            id: workspaceProjectsPage
 
-            projectModelType: ProjectsModel.CreatedProjectsModel
+            projectModelType: ProjectsModel.WorkspaceProjectsModel
             activeProjectId: root.activeProjectId
             list.visible: !stackView.pending
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2487,7 +2487,7 @@ void TestMerginApi::testExcludeFromSync()
 MerginProjectsList TestMerginApi::getProjectList( QString tag )
 {
   QSignalSpy spy( mApi,  &MerginApi::listProjectsFinished );
-  mApi->listProjects( QString(), tag, QString() );
+  mApi->listProjects( QString(), tag );
   spy.wait( TestUtils::SHORT_REPLY );
 
   return projectListFromSpy( spy );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -123,35 +123,48 @@ MerginSubscriptionInfo *MerginApi::subscriptionInfo() const
   return mSubscriptionInfo;
 }
 
-QString MerginApi::listProjects( const QString &searchExpression, const QString &flag, const QString &filterTag, const int page )
+QString MerginApi::listProjects( const QString &searchExpression, const QString &flag, const int page )
 {
-  bool authorize = !flag.isEmpty();
+  bool authorize = flag != "public";
+
   if ( ( authorize && !validateAuth() ) || mApiVersionStatus != MerginApiStatus::OK )
   {
     emit listProjectsFailed();
     return QString();
   }
 
-  QString workspace = mUserInfo->activeWorkspaceName();
-
   QUrlQuery query;
-  if ( !workspace.isEmpty() && !flag.isEmpty() )
+
+  if ( flag == "workspace" )
   {
-    query.addQueryItem( "only_namespace", workspace );
+    if ( mUserInfo->activeWorkspaceId() < 0 )
+    {
+      emit listProjectsFailed();
+      return QString();
+    }
+
+    query.addQueryItem( "only_namespace", mUserInfo->activeWorkspaceName() );
   }
-  if ( !filterTag.isEmpty() )
+  else if ( flag == "created" )
   {
-    query.addQueryItem( "tags", filterTag );
+    query.addQueryItem( "flag", "created" );
   }
+  else if ( flag == "shared" )
+  {
+    query.addQueryItem( "flag", "shared" );
+  }
+  else if ( flag == "public" )
+  {
+    query.addQueryItem( "only_public", "true" );
+  }
+
   if ( !searchExpression.isEmpty() )
   {
     query.addQueryItem( "name", searchExpression.toUtf8().toPercentEncoding() );
   }
-  if ( workspace.isEmpty() && !flag.isEmpty() )
-  {
-    query.addQueryItem( "flag", flag );
-  }
+
   query.addQueryItem( "order_params", QStringLiteral( "namespace_asc,name_asc" ) );
+
   // Required query parameters
   query.addQueryItem( "page", QString::number( page ) );
   query.addQueryItem( "per_page", QString::number( PROJECT_PER_PAGE ) );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -135,7 +135,7 @@ QString MerginApi::listProjects( const QString &searchExpression, const QString 
   QString workspace = mUserInfo->activeWorkspaceName();
 
   QUrlQuery query;
-  if ( !workspace.isEmpty() && !flag.isEmpty() )
+  if ( !workspace.isEmpty() )
   {
     query.addQueryItem( "only_namespace", workspace );
   }
@@ -147,11 +147,11 @@ QString MerginApi::listProjects( const QString &searchExpression, const QString 
   {
     query.addQueryItem( "name", searchExpression.toUtf8().toPercentEncoding() );
   }
-  if ( !flag.isEmpty() )
+  if ( workspace.isEmpty() && !flag.isEmpty() )
   {
     query.addQueryItem( "flag", flag );
   }
-  //query.addQueryItem( "order_params", QStringLiteral( "namespace_asc,name_asc" ) );
+  query.addQueryItem( "order_params", QStringLiteral( "namespace_asc,name_asc" ) );
   // Required query parameters
   query.addQueryItem( "page", QString::number( page ) );
   query.addQueryItem( "per_page", QString::number( PROJECT_PER_PAGE ) );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -135,7 +135,7 @@ QString MerginApi::listProjects( const QString &searchExpression, const QString 
   QString workspace = mUserInfo->activeWorkspaceName();
 
   QUrlQuery query;
-  if ( !workspace.isEmpty() )
+  if ( !workspace.isEmpty() && !flag.isEmpty() )
   {
     query.addQueryItem( "only_namespace", workspace );
   }

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -227,12 +227,11 @@ class MerginApi: public QObject
      * Eventually emits listProjectsFinished on which ProjectPanel (qml component) updates content.
      * \param searchExpression Search filter on projects name.
      * \param flag If defined, it is used to filter out projects tagged as 'created' or 'shared' with a authorized user
-     * \param filterTag Name of tag that fetched projects have to have.
      * \param page Requested page of projects.
      * \returns unique id of a request
      */
     Q_INVOKABLE QString listProjects( const QString &searchExpression = QStringLiteral(),
-                                      const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(),
+                                      const QString &flag = QStringLiteral(),
                                       const int page = 1 );
 
     /**


### PR DESCRIPTION
WE should not apply tag to list projects request if we are fetching projects from the specific workspace, as user might be not an author of the project.

Also re-enable use of order_params.