### PR TITLE
Disable main panel when it is not visible

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -47,7 +47,6 @@ ApplicationWindow {
       ]
 
       onStateChanged: {
-        console.log( " --- Root app state:", state )
         if ( stateManager.state === "map" ) {
           map.state = "view"
         }
@@ -254,6 +253,11 @@ ApplicationWindow {
 
         width: window.width
         height: InputStyle.rowHeightHeader
+
+        //
+        // In order to workaround the QTBUG-108689 - we need to disable main panel's buttons when something else occupies the space
+        //
+        enabled: mainPanel.height > map.mapExtentOffset
 
         y: window.height - height
 


### PR DESCRIPTION
Workaround for https://bugreports.qt.io/browse/QTBUG-108821 - Qt's bug with event distribution.

Made the `mainpanel` disabled when other windows occupy the space.

Re: QA Workspaces doc - Input - RC Full regresion with EE server (mergin related), else public - issue num. 6