### PR TITLE
Change switch workspace button and add toast to explain how to switch a workspace

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -15,6 +15,7 @@
 
 const QString AppSettings::INPUTAPP_GROUP_NAME = QStringLiteral( "inputApp" );
 const QString AppSettings::POSITION_PROVIDERS_GROUP = QStringLiteral( "inputApp/positionProviders" );
+const int AppSettings::WS_TOOLTIP_MAX_NUM_OF_OCCURENCIES = 5;
 
 AppSettings::AppSettings( QObject *parent ): QObject( parent )
 {
@@ -31,6 +32,8 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   bool legacyFolderMigrated = settings.value( QStringLiteral( "legacyFolderMigrated" ), false ).toBool();
   QString activeProviderId = settings.value( QStringLiteral( "activePositionProviderId" ) ).toString();
   bool autosync = settings.value( QStringLiteral( "autosyncAllowed" ), false ).toBool();
+  mWsTooltipShownCounter = settings.value( QStringLiteral( "wsTooltipCounter" ) ).toInt();
+
   settings.endGroup();
 
   setDefaultProject( path );
@@ -319,4 +322,20 @@ void AppSettings::setAutosyncAllowed( bool newAutosyncAllowed )
   mAutosyncAllowed = newAutosyncAllowed;
   setValue( QStringLiteral( "autosyncAllowed" ), newAutosyncAllowed );
   emit autosyncAllowedChanged( mAutosyncAllowed );
+}
+
+void AppSettings::wsTooltipShown()
+{
+  if ( mWsTooltipShownCounter < WS_TOOLTIP_MAX_NUM_OF_OCCURENCIES )
+  {
+    mWsTooltipShownCounter += 1;
+    setValue( QStringLiteral( "wsTooltipCounter" ), mWsTooltipShownCounter );
+
+    emit ignoreWsTooltipChanged();
+  }
+}
+
+bool AppSettings::ignoreWsTooltip() const
+{
+  return mWsTooltipShownCounter >= WS_TOOLTIP_MAX_NUM_OF_OCCURENCIES;
 }

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -33,6 +33,7 @@ class AppSettings: public QObject
     Q_PROPERTY( bool legacyFolderMigrated READ legacyFolderMigrated WRITE setLegacyFolderMigrated NOTIFY legacyFolderMigratedChanged )
     Q_PROPERTY( QString activePositionProviderId READ activePositionProviderId WRITE setActivePositionProviderId NOTIFY activePositionProviderIdChanged )
     Q_PROPERTY( bool autosyncAllowed READ autosyncAllowed WRITE setAutosyncAllowed NOTIFY autosyncAllowedChanged )
+    Q_PROPERTY( bool ignoreWsTooltip READ ignoreWsTooltip NOTIFY ignoreWsTooltipChanged )
 
   public:
     explicit AppSettings( QObject *parent = nullptr );
@@ -82,8 +83,13 @@ class AppSettings: public QObject
     bool autosyncAllowed() const;
     void setAutosyncAllowed( bool newAutosyncAllowed );
 
+    Q_INVOKABLE void wsTooltipShown();
+
+    bool ignoreWsTooltip() const; // ---> can be removed after migration to ws
+
     static const QString INPUTAPP_GROUP_NAME;
     static const QString POSITION_PROVIDERS_GROUP;
+    static const int WS_TOOLTIP_MAX_NUM_OF_OCCURENCIES; // ---> can be removed after migration to ws
 
   public slots:
     void setReuseLastEnteredValues( bool reuseLastEnteredValues );
@@ -103,6 +109,8 @@ class AppSettings: public QObject
     void activePositionProviderIdChanged( const QString & );
 
     void autosyncAllowedChanged( bool autosyncAllowed );
+
+    void ignoreWsTooltipChanged(); // ---> can be removed after migration to ws
 
   private:
     // Projects path
@@ -137,6 +145,7 @@ class AppSettings: public QObject
     QVariant value( const QString &key, const QVariant &defaultValue = QVariant() );
     QString mActivePositionProviderId;
     bool mAutosyncAllowed = false;
+    int mWsTooltipShownCounter = 0; // ---> can be removed after migration to ws
 };
 
 #endif // APPSETTINGS_H

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -613,6 +613,8 @@ Item {
           return qsTr("Public projects")
         }
 
+        tooltipText: qsTr("Your other projects are accessible%1by switching your workspace here").arg("\n")
+
         haveBackButton: root.activeProjectPath
         haveAccountButton: true
 
@@ -661,6 +663,21 @@ Item {
           __merginApi.pingMergin()
           projectsPage.refreshProjectList()
           pageFooter.setActiveButton( pageContent.state )
+
+          //
+          // Show ws explanation tooltip if user is in workspace projects, on the ws server,
+          // has more than one ws and has not seen it yet for too many times
+          //
+          if ( state === "created" ) {
+
+            if (__merginApi.apiSupportsWorkspaces &&
+                __merginApi.userInfo.hasMoreThanOneWorkspace &&
+                !__appSettings.ignoreWsTooltip ) {
+
+              __appSettings.wsTooltipShown()
+              headerRow.openTooltip()
+            }
+          }
         }
 
         Connections {

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -598,80 +598,39 @@ Item {
         }
       }
 
-      header: PanelHeader {
-        id: pageHeader
+      header: PanelHeaderV2 {
+        id: headerRow
 
-        titleText: qsTr("Projects")
-        color: InputStyle.clrPanelMain
-        height: InputStyle.rowHeightHeader
-        rowHeight: InputStyle.rowHeightHeader
+        width: projectsPage.width
 
-        onBack: {
-          if ( root.activeProjectId ) {
-            root.hidePanel()
+        headerTitle: {
+          if ( pageContent.state === "local" ) {
+            return qsTr("Downloaded projects")
           }
+          else if ( pageContent.state === "created" ) {
+            return __merginApi.userInfo.hasWorkspaces ? __merginApi.userInfo.activeWorkspaceName : qsTr("Projects")
+          }
+          return qsTr("Public projects")
         }
-        withBackButton: root.activeProjectPath
 
-        Item {
-          id: avatar
+        haveBackButton: root.activeProjectPath
+        haveAccountButton: true
 
-          width: InputStyle.rowHeightHeader * 0.8
-          height: InputStyle.rowHeightHeader
-          anchors.right: parent.right
-          anchors.rightMargin: InputStyle.panelMargin
+        onBackClicked: root.hidePanel()
+        onAccountClicked: {
+          if ( __merginApi.userAuth.hasAuthData() && __merginApi.apiVersionStatus === MerginApiStatus.OK ) {
 
-          Rectangle {
-            id: avatarImage
+            __merginApi.refreshUserData()
 
-            anchors.centerIn: parent
-            width: avatar.width
-            height: avatar.width
-            color: InputStyle.fontColor
-            radius: width*0.5
-            antialiasing: true
-
-            MouseArea {
-              anchors.fill: parent
-              onClicked: {
-                if ( __merginApi.userAuth.hasAuthData() && __merginApi.apiVersionStatus === MerginApiStatus.OK ) {
-                  __merginApi.getUserInfo()
-
-                  if ( __merginApi.apiSupportsSubscriptions ) {
-                    __merginApi.getWorkspaceInfo()
-                  }
-
-                  if ( __merginApi.serverType === MerginServerType.OLD ) {
-                    stackView.push( accountPanelComp )
-                  }
-                  else {
-                    stackView.push( workspaceAccountPageComp )
-                  }
-
-                }
-                else {
-                  root.openAuthPanel()
-                }
-              }
+            if ( __merginApi.serverType === MerginServerType.OLD ) {
+              stackView.push( accountPanelComp )
             }
-
-            Image {
-              id: userIcon
-
-              anchors.centerIn: avatarImage
-              source: InputStyle.accountIcon
-              height: avatarImage.height * 0.8
-              width: height
-              sourceSize.width: width
-              sourceSize.height: height
-              fillMode: Image.PreserveAspectFit
+            else {
+              stackView.push( workspaceAccountPageComp )
             }
-
-            ColorOverlay {
-              anchors.fill: userIcon
-              source: userIcon
-              color: "#FFFFFF"
-            }
+          }
+          else {
+            root.openAuthPanel()
           }
         }
       }
@@ -725,32 +684,13 @@ Item {
           }
         }
 
-        Button {
-          id: switchWorkspaceButton
-
-          visible: __merginApi.serverType !== MerginServerType.CE && pageContent.state === "created"
-          anchors {
-              left: parent.left
-              right: parent.right
-          }
-
-          contentItem: Text {
-            text: __merginApi.userInfo.activeWorkspaceId > 0 ? __merginApi.userInfo.activeWorkspaceName + " >" : qsTr("Switch workspace") + " >"
-            horizontalAlignment : Text.AlignLeft
-          }
-
-          onClicked: {
-            stackView.push(workspaceListComponent)
-          }
-        }
-
         StackLayout {
           id: projectListLayout
 
           anchors {
               left: parent.left
               right: parent.right
-              top: switchWorkspaceButton.visible? switchWorkspaceButton.bottom : parent.top
+              top: parent.top
               bottom: parent.bottom
           }
           currentIndex: pageFooter.currentIndex
@@ -857,7 +797,7 @@ Item {
             id: createdProjectsInnerBtn
 
             text: qsTr("Projects")
-            imageSource: InputStyle.accountIcon
+            imageSource: InputStyle.mapSearchIcon
             width: pageFooter.itemSize
 
             handleClicks: false

--- a/app/qml/components/PanelHeaderV2.qml
+++ b/app/qml/components/PanelHeaderV2.qml
@@ -18,12 +18,17 @@ Rectangle {
   id: root
 
   property string headerTitle
+  property string tooltipText
 
   property bool haveBackButton: true
   property bool haveAccountButton: false
 
   signal backClicked()
   signal accountClicked()
+
+  function openTooltip() {
+    tooltip.open()
+  }
 
   height: InputStyle.rowHeightHeader
   // set width manually
@@ -185,6 +190,45 @@ Rectangle {
           anchors.fill: userIcon
           source: userIcon
           color: "#FFFFFF"
+        }
+      }
+
+      ToolTip {
+        id: tooltip
+
+        y: avatarImage.y
+        x: title.x + InputStyle.smallGap
+
+        background: Item {
+
+          // arrow
+          Rectangle {
+            width: height
+            height: parent.height / 3
+
+            rotation: 45
+            color: InputStyle.panelBackgroundDarker
+
+            x: bgndRect.x + bgndRect.width - width / 2
+            y: bgndRect.y + bgndRect.height / 2 - width / 2
+          }
+
+          Rectangle {
+            id: bgndRect
+
+            width: parent.width
+            height: parent.height
+            color: InputStyle.panelBackgroundDarker
+            radius: InputStyle.cornerRadius
+            antialiasing: true
+          }
+        }
+
+        contentItem: Label {
+          text: root.tooltipText
+
+          font.pixelSize: InputStyle.fontPixelSizeSmall
+          color: InputStyle.fontColorWhite
         }
       }
     }

--- a/app/qml/components/PanelHeaderV2.qml
+++ b/app/qml/components/PanelHeaderV2.qml
@@ -9,6 +9,8 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 
 import ".."
 
@@ -16,63 +18,175 @@ Rectangle {
   id: root
 
   property string headerTitle
+
   property bool haveBackButton: true
+  property bool haveAccountButton: false
 
   signal backClicked()
+  signal accountClicked()
 
   height: InputStyle.rowHeightHeader
   // set width manually
 
   color: InputStyle.clrPanelMain
 
-  Text {
-    id: title
+  RowLayout {
+
+    spacing: InputStyle.panelSpacing
 
     anchors {
-      left: parent.left
-      leftMargin: backicon.width + InputStyle.panelMargin
-      right: parent.right
-      rightMargin: backicon.width + InputStyle.panelMargin
-      top: parent.top
-      bottom: parent.bottom
-    }
-
-    text: root.headerTitle
-
-    elide: Text.ElideMiddle
-    font.bold: true
-    color: InputStyle.fontColor
-    font.pixelSize: InputStyle.fontPixelSizeHeader
-
-    verticalAlignment: Text.AlignVCenter
-    horizontalAlignment: Text.AlignHCenter
-  }
-
-  Image {
-    id: backicon
-
-    anchors {
-      left: parent.left
+      fill: parent
       leftMargin: InputStyle.panelMargin
-      verticalCenter: parent.verticalCenter
+      rightMargin: InputStyle.panelMargin
     }
 
-    visible: root.haveBackButton
+    Item {
+      id: backIcon
 
-    source: InputStyle.backIconV2
-    sourceSize.width: InputStyle.closeBtnSize
-    sourceSize.height: InputStyle.closeBtnSize
+      Layout.preferredHeight: InputStyle.iconSizeLarge
+      Layout.preferredWidth: InputStyle.iconSizeLarge
 
-    MouseArea {
-      anchors {
-        fill: parent // make the click area bigger
-        leftMargin: -InputStyle.buttonClickArea
-        topMargin: -InputStyle.buttonClickArea
-        rightMargin: -InputStyle.buttonClickArea
-        bottomMargin: -InputStyle.buttonClickArea
+      visible: root.haveBackButton
+
+      Image {
+        anchors {
+          left: parent.left
+          verticalCenter: parent.verticalCenter
+        }
+
+        source: InputStyle.backIconV2
+        sourceSize.width: InputStyle.closeBtnSize
+        sourceSize.height: InputStyle.closeBtnSize
+
+        MouseArea {
+          anchors {
+            fill: parent // make the click area bigger
+            leftMargin: -InputStyle.buttonClickArea
+            topMargin: -InputStyle.buttonClickArea
+            rightMargin: -InputStyle.buttonClickArea
+            bottomMargin: -InputStyle.buttonClickArea
+          }
+
+          onClicked: root.backClicked()
+        }
       }
+    }
 
-      onClicked: root.backClicked()
+    Item {
+      id: backIconSpacer
+
+      Layout.preferredHeight: parent.height
+      Layout.preferredWidth: {
+        if ( !root.haveBackButton && !root.haveAccountButton ) {
+          // no avatar and no back button
+          return 0;
+        }
+        else if ( root.haveBackButton ) {
+          // no account button
+          return 0;
+        }
+        else if ( root.haveAccountButton ) {
+          // no back button
+          return avatar.width;
+        }
+        // both visible
+        let diff = avatar.width - backIcon.width;
+        return Math.max( diff, 0 );
+      }
+    }
+
+    Text {
+      id: title
+
+      Layout.fillWidth: true
+      Layout.preferredHeight: parent.height
+
+      text: root.headerTitle
+
+      elide: Text.ElideMiddle
+      font.bold: true
+      color: InputStyle.fontColor
+      font.pixelSize: InputStyle.fontPixelSizeBig
+
+      verticalAlignment: Text.AlignVCenter
+      horizontalAlignment: Text.AlignHCenter
+    }
+
+    Item {
+      id: avatarSpacer
+
+      Layout.preferredHeight: parent.height
+      Layout.preferredWidth: {
+        if ( !root.haveBackButton && !root.haveAccountButton ) {
+          // no avatar and no back button
+          return 0;
+        }
+        else if ( root.haveAccountButton ) {
+          // no back button
+          return 0;
+        }
+        else if ( root.haveBackButton ) {
+          // no avatar
+          return backIcon.width;
+        }
+        // both visible
+        let diff = backIcon.width - avatar.width;
+        return Math.max( diff, 0 );
+      }
+    }
+
+    // account head
+    Item {
+      id: avatar
+
+      Layout.preferredHeight: InputStyle.iconSizeXLarge
+      Layout.preferredWidth: InputStyle.iconSizeXLarge
+
+      visible: root.haveAccountButton
+
+      Rectangle {
+        id: avatarImage
+
+        anchors.centerIn: parent
+
+        width: avatar.width
+        height: avatar.width
+
+        radius: InputStyle.circleRadius
+        color: InputStyle.fontColor
+
+        antialiasing: true
+
+        MouseArea {
+          anchors {
+            fill: parent
+            leftMargin: -InputStyle.buttonClickArea
+            topMargin: -InputStyle.buttonClickArea
+            rightMargin: -InputStyle.buttonClickArea
+            bottomMargin: -InputStyle.buttonClickArea
+          }
+
+          onClicked: root.accountClicked()
+        }
+
+        Image {
+          id: userIcon
+
+          anchors.centerIn: avatarImage
+          source: InputStyle.accountIcon
+          height: avatarImage.height * 0.8
+          width: height
+          sourceSize.width: width
+          sourceSize.height: height
+          fillMode: Image.PreserveAspectFit
+        }
+
+        ColorOverlay {
+          anchors.fill: userIcon
+          source: userIcon
+          color: "#FFFFFF"
+        }
+      }
     }
   }
 }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3506,6 +3506,21 @@ void MerginApi::signOut()
   clearAuth();
 }
 
+void MerginApi::refreshUserData()
+{
+  getUserInfo();
+
+  if ( apiSupportsWorkspaces() )
+  {
+    getWorkspaceInfo();
+    // getServiceInfo is called automatically when workspace info finishes
+  }
+  else if ( mServerType == MerginServerType::OLD )
+  {
+    getServiceInfo();
+  }
+}
+
 void MerginApi::createWorkspaceReplyFinished()
 {
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -502,6 +502,11 @@ class MerginApi: public QObject
     Q_INVOKABLE void signOut();
 
     /**
+     * Emits API calls that bear user information like username, workspaces and service
+     */
+    Q_INVOKABLE void refreshUserData();
+
+    /**
      * Returns true if server supports workspaces
      */
     bool apiSupportsWorkspaces();

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -27,6 +27,7 @@ void MerginUserInfo::clear()
   mInvitations.clear();
 
   emit hasWorkspacesChanged();
+  emit hasMoreThanOneWorkspaceChanged();
   emit userInfoChanged();
 }
 
@@ -69,6 +70,7 @@ void MerginUserInfo::setFromJson( QJsonObject docObj )
 
   emit userInfoChanged();
   emit hasWorkspacesChanged();
+  emit hasMoreThanOneWorkspaceChanged();
 }
 
 QString MerginUserInfo::email() const
@@ -233,4 +235,9 @@ MerginInvitation MerginInvitation::fromJsonObject( const QJsonObject &invitation
 QString MerginUserInfo::name() const
 {
   return mName;
+}
+
+bool MerginUserInfo::hasMoreThanOneWorkspace() const
+{
+  return mWorkspaces.size() > 1;
 }

--- a/core/merginuserinfo.h
+++ b/core/merginuserinfo.h
@@ -39,6 +39,7 @@ class MerginUserInfo: public QObject
     Q_PROPERTY( int activeWorkspaceId READ activeWorkspaceId NOTIFY activeWorkspaceChanged )
     Q_PROPERTY( bool hasInvitations READ hasInvitations NOTIFY userInfoChanged )
     Q_PROPERTY( bool hasWorkspaces READ hasWorkspaces NOTIFY hasWorkspacesChanged )
+    Q_PROPERTY( bool hasMoreThanOneWorkspace READ hasMoreThanOneWorkspace NOTIFY hasMoreThanOneWorkspaceChanged )
 
   public:
     explicit MerginUserInfo( QObject *parent = nullptr );
@@ -64,10 +65,13 @@ class MerginUserInfo: public QObject
     Q_INVOKABLE void setActiveWorkspace( int newWorkspace );
     void setWorkspaces( QMap<int, QString> workspaces );
 
+    bool hasMoreThanOneWorkspace() const;
+
   signals:
     void userInfoChanged();
     void activeWorkspaceChanged();
     void hasWorkspacesChanged();
+    void hasMoreThanOneWorkspaceChanged();
 
   private:
     QString mName;
@@ -75,6 +79,7 @@ class MerginUserInfo: public QObject
     QMap<int, QString> mWorkspaces;
     QList<MerginInvitation> mInvitations;
     int mActiveWorkspace = -1;
+    bool mHasMoreThanOneWorkspace;
 };
 
 #endif // MERGINUSERINFO_H


### PR DESCRIPTION
You can now switch workspace only from `account page`.

<table>
  <tr>
    <th>Previous</th>
    <th>Now (see page title - ws)</th>
    <th>With tooltip</th>
  </tr>
  <tr>
    <td>
<img width="300" src="https://user-images.githubusercontent.com/22449698/214523964-6d7d37ab-85a4-4d43-b603-63a523e27b76.jpeg">
</td>
    <td><img width="300" alt="Screenshot 2023-01-25 at 10 03 50" src="https://user-images.githubusercontent.com/22449698/214523405-2d5e579b-ca8f-4985-b26b-f3501cdb5af9.png">
</td>
    <td><img width="300" alt="Screenshot 2023-01-25 at 10 03 45" src="https://user-images.githubusercontent.com/22449698/214523373-78bb1ebf-6521-4c23-9381-dceeca9cfc7a.png"></td>
  </tr>
  <tr>
  </tr>
 </table>

Also fixes a bug that `/workspace/<id>` was not called on profile page.