### PR TITLE
extract error message from the server reply containing automatic validation results

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2709,3 +2709,15 @@ void TestMerginApi::testServerUpgrade()
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( mApi->serverType(), MerginServerType::SAAS );
 }
+
+void TestMerginApi::testServerError()
+{
+  QString msg = mApi->extractServerErrorMsg( "{\"detail\": \"Some error occured.\"}" );
+  QCOMPARE( msg, QStringLiteral( "Some error occured." ) );
+
+  msg = mApi->extractServerErrorMsg( "{\"name\": \"Some error occured.\"}" );
+  QCOMPARE( msg, QStringLiteral( "[can't parse server error]" ) );
+
+  msg = mApi->extractServerErrorMsg( "{\"name\": [\"Field must be between 4 and 25 characters long.\"]}" );
+  QCOMPARE( msg, QStringLiteral( "Field must be between 4 and 25 characters long." ) );
+}

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -89,6 +89,8 @@ class TestMerginApi: public QObject
 
     void testServerUpgrade();
 
+    void testServerError();
+
   private:
     MerginApi *mApi;
     std::unique_ptr<ProjectsModel> mLocalProjectsModel;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1351,14 +1351,27 @@ QString MerginApi::extractServerErrorMsg( const QByteArray &data )
   if ( doc.isObject() )
   {
     QJsonObject obj = doc.object();
-    QJsonValue vDetail = obj.value( "detail" );
-    if ( vDetail.isString() )
+    if ( obj.contains( QStringLiteral( "detail" ) ) )
     {
-      serverMsg = vDetail.toString();
+      QJsonValue vDetail = obj.value( "detail" );
+      if ( vDetail.isString() )
+      {
+        serverMsg = vDetail.toString();
+      }
+      else if ( vDetail.isObject() )
+      {
+        serverMsg = QJsonDocument( vDetail.toObject() ).toJson();
+      }
     }
-    else if ( vDetail.isObject() )
+    else if ( obj.contains( QStringLiteral( "name" ) ) )
     {
-      serverMsg = QJsonDocument( vDetail.toObject() ).toJson();
+      QJsonArray errors = obj.value( "name" ).toArray();
+      QStringList messages;
+      for ( auto it = errors.constBegin(); it != errors.constEnd(); ++it )
+      {
+        messages << it->toString();
+      }
+      serverMsg = messages.join( " " );
     }
     else
     {

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1346,7 +1346,7 @@ bool MerginApi::extractProjectName( const QString &sourceString, QString &projec
 
 QString MerginApi::extractServerErrorMsg( const QByteArray &data )
 {
-  QString serverMsg;
+  QString serverMsg = "[can't parse server error]";
   QJsonDocument doc = QJsonDocument::fromJson( data );
   if ( doc.isObject() )
   {
@@ -1365,13 +1365,17 @@ QString MerginApi::extractServerErrorMsg( const QByteArray &data )
     }
     else if ( obj.contains( QStringLiteral( "name" ) ) )
     {
-      QJsonArray errors = obj.value( "name" ).toArray();
-      QStringList messages;
-      for ( auto it = errors.constBegin(); it != errors.constEnd(); ++it )
+      QJsonValue val = obj.value( "name" );
+      if ( val.isArray() )
       {
-        messages << it->toString();
+        QJsonArray errors = val.toArray();
+        QStringList messages;
+        for ( auto it = errors.constBegin(); it != errors.constEnd(); ++it )
+        {
+          messages << it->toString();
+        }
+        serverMsg = messages.join( " " );
       }
-      serverMsg = messages.join( " " );
     }
     else
     {


### PR DESCRIPTION
For instance, displays meaningful error for the case when workspace name is too short.