### PR TITLE
Reset action required flag when clearing subscription information

### DIFF
--- a/core/merginsubscriptioninfo.cpp
+++ b/core/merginsubscriptioninfo.cpp
@@ -24,6 +24,7 @@ void MerginSubscriptionInfo::clearSubscriptionData()
   mSubscriptionId = -1;
   mOwnsActiveSubscription = false;
   mCanAccessSubscription = false;
+  mActionRequired = false;
 }
 
 void MerginSubscriptionInfo::clearPlanInfo()


### PR DESCRIPTION
Action required flag was still shown even when user logged out / switched accounts