### PR TITLE
Show invitations page on startup and  after user logs in

### DIFF
--- a/app/qml/ManageInvitationsPage.qml
+++ b/app/qml/ManageInvitationsPage.qml
@@ -22,11 +22,13 @@ Page {
   signal back
   signal createWorkspaceRequested
 
+  property bool haveBack: false
+
   header: PanelHeaderV2 {
     width: root.width
     headerTitle: qsTr("Join a workspace")
     onBackClicked: root.back()
-    haveBackButton: false
+    haveBackButton: root.haveBack
   }
 
   ColumnLayout {

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -1156,8 +1156,12 @@ Item {
     function onUserInfoReplyFinished() {
       openInvitationsListener.showInvitationsList = false;
 
-      // let's double check if registration page is not opened
+      // let's not show invitations when registration finish page is opened
       if ( stackView.containsPage("registrationFinishPanel") ) {
+        return;
+      }
+
+      if ( !__merginApi.userAuth.hasAuthData() ) {
         return;
       }
 

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -164,6 +164,17 @@ Item {
       }
     }
 
+    function containsPage( pageName ) {
+      for ( let i = 0; i < stackView.depth; i++ ) {
+        let item = stackView.get( i );
+
+        if ( item && item.objectName && item.objectName === pageName ) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     function switchUI() {
       stackView.clear( StackView.Immediate )
 
@@ -1027,6 +1038,26 @@ Item {
   }
 
   Component {
+    id: invitationsPanelComponent
+
+    ManageInvitationsPage {
+      objectName: "invitationsPanel"
+      haveBack: true
+      onBack: {
+        stackView.pop( null )
+      }
+
+      Connections {
+        target: __merginApi
+
+        function onProcessInvitationFinished() {
+          stackView.pop( null )
+        }
+      }
+    }
+  }
+
+  Component {
     id: registrationFinishComponent
 
     RegistrationFinishPage {
@@ -1077,6 +1108,10 @@ Item {
         root.refreshProjects()
         root.forceActiveFocus()
       }
+      else {
+        // log out - reenable openInvitationsListener
+        openInvitationsListener.showInvitationsList = true
+      }
     }
 
     function onAuthFailed() {
@@ -1106,6 +1141,28 @@ Item {
     function onWorkspaceCreated(workspace, result) {
       if (result) {
         stackView.popPage("createWorkspacePanel")
+      }
+    }
+  }
+
+  Connections {
+    id: openInvitationsListener
+
+    property bool showInvitationsList: true
+
+    target: __merginApi
+    enabled: __merginApi.apiSupportsWorkspaces && openInvitationsListener.showInvitationsList
+
+    function onUserInfoReplyFinished() {
+      openInvitationsListener.showInvitationsList = false;
+
+      // let's double check if registration page is not opened
+      if ( stackView.containsPage("registrationFinishPanel") ) {
+        return;
+      }
+
+      if ( __merginApi.userInfo.hasInvitations ) {
+        stackView.push( invitationsPanelComponent )
       }
     }
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -86,9 +86,18 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   GEODIFF_setLoggerCallback( &GeodiffUtils::log );
   GEODIFF_setMaximumLoggerLevel( GEODIFF_LoggerLevel::LevelDebug );
 
-  // check if the cache is up to date
+  //
+  // check if the cache is up to date:
+  //  - server url and type
+  //  - user auth and info
+  //  - workspace info
+  //
+
   getServerConfig();
   pingMergin();
+
+  QObject::connect( this, &MerginApi::pingMerginFinished, this, &MerginApi::getUserInfo, Qt::SingleShotConnection );
+  QObject::connect( this, &MerginApi::userInfoReplyFinished, this, &MerginApi::getWorkspaceInfo, Qt::SingleShotConnection );
 }
 
 void MerginApi::loadCache()


### PR DESCRIPTION
We did not clearly show that a user has a pending invitation previously - now we show that there is a pending invitation each time the app is opened or the user logs in.

I needed to add call to `/v1/user/profile` right after server type is recognized to get list of invitations.

> Note: this implementation is not the best solution 🫣 We need a slight redesign to MerginAPI now with workspaces.

<img src="https://user-images.githubusercontent.com/22449698/215356582-a37a9ded-db61-4ca6-a8aa-750eb5508745.jpg" width=300>
