### PR TITLE
use invitations form the user info when populating manage invitations page

### DIFF
--- a/app/invitationsmodel.cpp
+++ b/app/invitationsmodel.cpp
@@ -24,8 +24,16 @@ void InvitationsModel::initializeModel()
     return;
   }
 
-  QObject::connect( mApi, &MerginApi::listInvitationsFinished, this, &InvitationsModel::onListInvitationsFinished );
-  listInvitations();
+  if ( mFetchFromServer )
+  {
+    QObject::connect( mApi, &MerginApi::listInvitationsFinished, this, &InvitationsModel::onListInvitationsFinished );
+    listInvitations();
+  }
+  else
+  {
+    setModelIsLoading( true );
+    onListInvitationsFinished( mApi->userInfo()->invitations() );
+  }
 
   emit modelInitialized();
 }
@@ -83,12 +91,13 @@ void InvitationsModel::setMerginApi( MerginApi *merginApi )
   }
 
   mApi = merginApi;
-  emit merginApiChanged( mApi );
 
   if ( mApi )
   {
     connect( mApi, &MerginApi::processInvitationFinished, this, &InvitationsModel::listInvitations );
   }
+
+  emit merginApiChanged( mApi );
 }
 
 bool InvitationsModel::isLoading() const
@@ -100,4 +109,15 @@ void InvitationsModel::setModelIsLoading( bool state )
 {
   mModelIsLoading = state;
   emit isLoadingChanged( mModelIsLoading );
+}
+
+bool InvitationsModel::fetchFromServer() const
+{
+  return mFetchFromServer;
+}
+
+void InvitationsModel::setFetchFromServer( bool fetch )
+{
+  mFetchFromServer = fetch;
+  emit fetchFromServerChanged( mFetchFromServer );
 }

--- a/app/invitationsmodel.h
+++ b/app/invitationsmodel.h
@@ -22,6 +22,7 @@ class InvitationsModel : public QStandardItemModel
 
     Q_PROPERTY( MerginApi *merginApi READ merginApi WRITE setMerginApi NOTIFY merginApiChanged )
     Q_PROPERTY( bool isLoading READ isLoading NOTIFY isLoadingChanged )
+    Q_PROPERTY( bool fetchFromServer READ fetchFromServer WRITE setFetchFromServer NOTIFY fetchFromServerChanged )
 
   public:
 
@@ -34,6 +35,8 @@ class InvitationsModel : public QStandardItemModel
     void setMerginApi( MerginApi *merginApi );
 
     bool isLoading() const;
+    bool fetchFromServer() const;
+    void setFetchFromServer( bool fetch );
 
     void processInvitation( const QString &uuid, bool accept );
 
@@ -43,6 +46,7 @@ class InvitationsModel : public QStandardItemModel
   signals:
     void merginApiChanged( MerginApi *api );
     void isLoadingChanged( bool isLoading );
+    void fetchFromServerChanged( bool fetch );
     void modelInitialized();
 
   private:
@@ -50,6 +54,7 @@ class InvitationsModel : public QStandardItemModel
     void initializeModel();
 
     bool mModelIsLoading;
+    bool mFetchFromServer = true;
     MerginApi *mApi = nullptr; // not owned
 };
 

--- a/app/invitationsproxymodel.cpp
+++ b/app/invitationsproxymodel.cpp
@@ -24,6 +24,11 @@ bool InvitationsProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex &
   QModelIndex sourceIndex = sourceModel()->index( sourceRow, 0, sourceParent );
   QDateTime expiration = sourceModel()->data( sourceIndex, Qt::StatusTipRole ).toDateTime();
 
+  if ( !expiration.isValid() )
+  {
+    return true;
+  }
+
   return expiration > QDateTime::currentDateTimeUtc();
 }
 

--- a/app/qml/ManageInvitationsPage.qml
+++ b/app/qml/ManageInvitationsPage.qml
@@ -104,7 +104,6 @@ Page {
         Repeater {
           id: invRepeater
 
-          // TODO: change model to userInfo -> invitations
           model: InvitationsProxyModel {
             invitationsSourceModel: InvitationsModel {
               merginApi: __merginApi

--- a/app/qml/ManageInvitationsPage.qml
+++ b/app/qml/ManageInvitationsPage.qml
@@ -108,6 +108,7 @@ Page {
           model: InvitationsProxyModel {
             invitationsSourceModel: InvitationsModel {
               merginApi: __merginApi
+              fetchFromServer: false
             }
           }
 


### PR DESCRIPTION
When showing user invitations after login, we should not send another request to the server to list invitations, as user profile already has this information. Send request to the server only when switch workspace page is opened, because in this case we want to get also any new invitations.

**NOTE**: ~~this won't work correctly now, as user profile does not include expiration date for invitations~~