### PR TITLE
clarify fork origin for qgsquick files

### DIFF
--- a/app/map/inputcoordinatetransformer.cpp
+++ b/app/map/inputcoordinatetransformer.cpp
@@ -7,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickcoordinatetransformer.cpp by (C) 2017 by Matthias Kuhn
+ */
+
 #include "inputcoordinatetransformer.h"
 #include "qgslogger.h"
 

--- a/app/map/inputcoordinatetransformer.h
+++ b/app/map/inputcoordinatetransformer.h
@@ -7,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickcoordinatetransformer.h by (C) 2017 by Matthias Kuhn
+ */
+
 #ifndef INPUTCOORDINATETRANSFORMER_H
 #define INPUTCOORDINATETRANSFORMER_H
 

--- a/app/map/inputmapcanvasmap.cpp
+++ b/app/map/inputmapcanvasmap.cpp
@@ -7,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickmapcanvasmap.cpp by (C) 2014 by Matthias Kuhn
+ */
+
 #include <QQuickWindow>
 #include <QSGSimpleTextureNode>
 #include <QScreen>

--- a/app/map/inputmapcanvasmap.h
+++ b/app/map/inputmapcanvasmap.h
@@ -7,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickmapcanvasmap.h by (C) 2014 by Matthias Kuhn
+ */
+
 #ifndef INPUTMAPCANVASMAP_H
 #define INPUTMAPCANVASMAP_H
 

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -7,6 +7,10 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickmapsettings.cpp by (C) 2014 by Matthias Kuhn
+ */
 
 #include "qgis.h"
 #include "inputmapsettings.h"

--- a/app/map/inputmapsettings.h
+++ b/app/map/inputmapsettings.h
@@ -7,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickmapsettings.h by (C) 2014 by Matthias Kuhn
+ */
+
 #ifndef INPUTMAPSETTINGS_H
 #define INPUTMAPSETTINGS_H
 

--- a/app/map/inputmaptransform.cpp
+++ b/app/map/inputmaptransform.cpp
@@ -7,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickmaptransform.cpp by (C) 2014 by Matthias Kuhn
+ */
+
 #include "inputmaptransform.h"
 
 void InputMapTransform::applyTo( QMatrix4x4 *matrix ) const

--- a/app/map/inputmaptransform.h
+++ b/app/map/inputmaptransform.h
@@ -7,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickmaptransform.h by (C) 2014 by Matthias Kuhn
+ */
+
 #ifndef INPUTMAPTRANSFORM_H
 #define INPUTMAPTRANSFORM_H
 

--- a/app/qml/map/MapCanvas.qml
+++ b/app/qml/map/MapCanvas.qml
@@ -1,10 +1,4 @@
 /***************************************************************************
- inputmapcanvas.qml
-  --------------------------------------
-  Date                 : 10.12.2014
-  Copyright            : (C) 2014 by Matthias Kuhn
-  Email                : matthias@opengis.ch
- ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -13,6 +7,11 @@
  *                                                                         *
  ***************************************************************************/
 
+/*
+ * The source code forked from https://github.com/qgis/QGIS on 25th Nov 2022
+ * File: qgsquickmapcanvas.qml by (C) 2014 by Matthias Kuhn
+ */
+ 
 import QtQuick
 import QtQuick.Controls
 import QtQml


### PR DESCRIPTION
https://github.com/qgis/QGIS/pull/51347#issuecomment-1410060355

revert back (c) and attribution removed in https://github.com/MerginMaps/input/commit/bbc5cb845a528d264f579163e5623e89812e3711#diff-093e243bd0c5c7aac05b323490375ea112dfa0ed63f36828e4125b6db7192ed7