### PR TITLE
Fix field validations

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -1112,6 +1112,8 @@ bool AttributeController::setFormValue( const QUuid &id, QVariant value )
     QgsField field = item->field();
     QVariant val( value );
 
+    item->setRawValue( val );
+
     if ( !field.convertCompatible( val ) )
     {
       QString msg( tr( "Value \"%1\" %4 could not be converted to a compatible value for field %2(%3)." ).arg( value.toString(), field.name(), field.typeName(), value.isNull() ? "NULL" : "NOT NULL" ) );

--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -458,7 +458,6 @@ void AttributeController::updateOnFeatureChange()
         {
           mFeatureLayerPair.featureRef().setAttribute( fieldIndex, rememberedValue );
           itemData->setRawValue( rememberedValue );
-          emit formDataChanged( itemData->id(), { AttributeFormModel::RawValue } );
         }
       }
     }
@@ -1120,7 +1119,6 @@ bool AttributeController::setFormValue( const QUuid &id, QVariant value )
 
     item->setRawValue( val );
     emit formDataChanged( item->id(), { AttributeFormModel::RawValue } );
-    emit rawValueChanged();
 
     if ( !field.convertCompatible( val ) )
     {

--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -617,7 +617,6 @@ bool AttributeController::recalculateDefaultValues(
 
 void AttributeController::recalculateDerivedItems( bool isFormValueChange, bool isFirstUpdateOfNewFeature )
 {
-  qDebug() << "AttributeController::recalculateDerivedItems";
   QSet<QUuid> changedFormItems;
 
   QgsVectorLayer *layer = mFeatureLayerPair.layer();

--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -446,6 +446,7 @@ void AttributeController::updateOnFeatureChange()
       int fieldIndex = itemData->fieldIndex();
       const QVariant newVal = feature.attribute( fieldIndex );
       mFormItems[itemData->id()]->setOriginalValue( newVal );
+      mFormItems[itemData->id()]->setRawValue( newVal ); // we need to set raw value as well, as we use it in form now
       if ( mRememberAttributesController && isNewFeature() ) // this is a new feature
       {
         QVariant rememberedValue;

--- a/app/attributes/attributecontroller.h
+++ b/app/attributes/attributecontroller.h
@@ -167,7 +167,6 @@ class  AttributeController : public QObject
     void featureIdChanged();
     void changesCommited();
     void commitFailed();
-    void rawValueChanged();
 
   private:
     void clearAll();

--- a/app/attributes/attributecontroller.h
+++ b/app/attributes/attributecontroller.h
@@ -167,6 +167,7 @@ class  AttributeController : public QObject
     void featureIdChanged();
     void changesCommited();
     void commitFailed();
+    void rawValueChanged();
 
   private:
     void clearAll();

--- a/app/attributes/attributedata.cpp
+++ b/app/attributes/attributedata.cpp
@@ -204,6 +204,16 @@ QgsRelation FormItem::relation() const
   return mRelation;
 }
 
+QVariant FormItem::rawValue() const
+{
+  return mRawValue;
+}
+
+void FormItem::setRawValue( const QVariant &rawValue )
+{
+  mRawValue = rawValue;
+}
+
 
 TabItem::TabItem( const int &id,
                   const QString &name,

--- a/app/attributes/attributedata.h
+++ b/app/attributes/attributedata.h
@@ -115,6 +115,9 @@ class FormItem
     QVariant originalValue() const;
     void setOriginalValue( const QVariant &originalValue );
 
+    QVariant rawValue() const;
+    void setRawValue( const QVariant &rawValue );
+
     QgsRelation relation() const;
     QString fieldError() const;
 
@@ -135,6 +138,7 @@ class FormItem
     FieldValidator::ValidationStatus mValidationStatus = FieldValidator::Valid;
     bool mVisible = false;
     QVariant mOriginalValue; // original unmodified value
+    QVariant mRawValue;
 
     const QgsRelation mRelation; // empty if type is field
 };

--- a/app/attributes/attributeformmodel.cpp
+++ b/app/attributes/attributeformmodel.cpp
@@ -57,7 +57,8 @@ QVariant AttributeFormModel::data( const QModelIndex &index, int role ) const
     case Type:
       return item->type();
     case AttributeValue:
-      return mController->formValue( item->fieldIndex() );
+      //return mController->formValue( item->fieldIndex() );
+      return item->rawValue();
     case AttributeValueIsNull:
       return mController->formValue( item->fieldIndex() ).isNull();
     case AttributeEditable:

--- a/app/attributes/attributeformmodel.cpp
+++ b/app/attributes/attributeformmodel.cpp
@@ -57,8 +57,7 @@ QVariant AttributeFormModel::data( const QModelIndex &index, int role ) const
     case Type:
       return item->type();
     case AttributeValue:
-      //return mController->formValue( item->fieldIndex() );
-      return item->rawValue();
+      return mController->formValue( item->fieldIndex() );
     case AttributeValueIsNull:
       return mController->formValue( item->fieldIndex() ).isNull();
     case AttributeEditable:

--- a/app/attributes/attributeformmodel.cpp
+++ b/app/attributes/attributeformmodel.cpp
@@ -169,7 +169,8 @@ bool AttributeFormModel::setData( const QModelIndex &index, const QVariant &valu
     case AttributeValue:
     {
       const FormItem *item = mController->formItem( uuid );
-      if ( mController->formValue( item->fieldIndex() ) == value )
+      //if ( mController->formValue( item->fieldIndex() ) == value )
+      if ( item->rawValue() == value )
       {
         return false;
       }

--- a/app/attributes/attributeformmodel.cpp
+++ b/app/attributes/attributeformmodel.cpp
@@ -82,6 +82,8 @@ QVariant AttributeFormModel::data( const QModelIndex &index, int role ) const
       return item->validationStatus();
     case Relation:
       return QVariant::fromValue( item->relation() );
+    case RawValue:
+      return item->rawValue();
     default:
       return QVariant();
   }
@@ -125,6 +127,7 @@ QHash<int, QByteArray> AttributeFormModel::roleNames() const
   roles[ValidationMessage] = QByteArray( "ValidationMessage" );
   roles[ValidationStatus] = QByteArray( "ValidationStatus" );
   roles[Relation] = QByteArray( "Relation" );
+  roles[RawValue] = QByteArray( "RawValue" );
 
   return roles;
 }

--- a/app/attributes/attributeformmodel.h
+++ b/app/attributes/attributeformmodel.h
@@ -60,7 +60,8 @@ class  AttributeFormModel : public QAbstractListModel
       Visible, //!< Field visible
       ValidationMessage,
       ValidationStatus,
-      Relation //!< QgsRelation instance for this item, empty if it is not a relation
+      Relation, //!< QgsRelation instance for this item, empty if it is not a relation
+      RawValue
     };
 
     Q_ENUM( AttributeFormRoles )

--- a/app/attributes/fieldvalidator.cpp
+++ b/app/attributes/fieldvalidator.cpp
@@ -35,7 +35,8 @@ FieldValidator::ValidationStatus FieldValidator::validate( const FeatureLayerPai
   ValidationStatus state = Valid;
 
   const QgsField field = item.field();
-  QVariant value = pair.feature().attribute( item.fieldIndex() );
+  //QVariant value = pair.feature().attribute( item.fieldIndex() );
+  QVariant value = item.rawValue();
 
   bool isNumeric = item.editorWidgetType() == QStringLiteral( "Range" ) || field.isNumeric();
   if ( isNumeric )

--- a/app/attributes/fieldvalidator.cpp
+++ b/app/attributes/fieldvalidator.cpp
@@ -35,7 +35,6 @@ FieldValidator::ValidationStatus FieldValidator::validate( const FeatureLayerPai
   ValidationStatus state = Valid;
 
   const QgsField field = item.field();
-  //QVariant value = pair.feature().attribute( item.fieldIndex() );
   QVariant value = item.rawValue();
 
   bool isNumeric = item.editorWidgetType() == QStringLiteral( "Range" ) || field.isNumeric();

--- a/app/invitationsmodel.cpp
+++ b/app/invitationsmodel.cpp
@@ -24,8 +24,16 @@ void InvitationsModel::initializeModel()
     return;
   }
 
-  QObject::connect( mApi, &MerginApi::listInvitationsFinished, this, &InvitationsModel::onListInvitationsFinished );
-  listInvitations();
+  if ( mFetchFromServer )
+  {
+    QObject::connect( mApi, &MerginApi::listInvitationsFinished, this, &InvitationsModel::onListInvitationsFinished );
+    listInvitations();
+  }
+  else
+  {
+    setModelIsLoading( true );
+    onListInvitationsFinished( mApi->userInfo()->invitations() );
+  }
 
   emit modelInitialized();
 }
@@ -83,12 +91,13 @@ void InvitationsModel::setMerginApi( MerginApi *merginApi )
   }
 
   mApi = merginApi;
-  emit merginApiChanged( mApi );
 
   if ( mApi )
   {
     connect( mApi, &MerginApi::processInvitationFinished, this, &InvitationsModel::listInvitations );
   }
+
+  emit merginApiChanged( mApi );
 }
 
 bool InvitationsModel::isLoading() const
@@ -100,4 +109,15 @@ void InvitationsModel::setModelIsLoading( bool state )
 {
   mModelIsLoading = state;
   emit isLoadingChanged( mModelIsLoading );
+}
+
+bool InvitationsModel::fetchFromServer() const
+{
+  return mFetchFromServer;
+}
+
+void InvitationsModel::setFetchFromServer( bool fetch )
+{
+  mFetchFromServer = fetch;
+  emit fetchFromServerChanged( mFetchFromServer );
 }

--- a/app/invitationsmodel.h
+++ b/app/invitationsmodel.h
@@ -22,6 +22,7 @@ class InvitationsModel : public QStandardItemModel
 
     Q_PROPERTY( MerginApi *merginApi READ merginApi WRITE setMerginApi NOTIFY merginApiChanged )
     Q_PROPERTY( bool isLoading READ isLoading NOTIFY isLoadingChanged )
+    Q_PROPERTY( bool fetchFromServer READ fetchFromServer WRITE setFetchFromServer NOTIFY fetchFromServerChanged )
 
   public:
 
@@ -34,6 +35,8 @@ class InvitationsModel : public QStandardItemModel
     void setMerginApi( MerginApi *merginApi );
 
     bool isLoading() const;
+    bool fetchFromServer() const;
+    void setFetchFromServer( bool fetch );
 
     void processInvitation( const QString &uuid, bool accept );
 
@@ -43,6 +46,7 @@ class InvitationsModel : public QStandardItemModel
   signals:
     void merginApiChanged( MerginApi *api );
     void isLoadingChanged( bool isLoading );
+    void fetchFromServerChanged( bool fetch );
     void modelInitialized();
 
   private:
@@ -50,6 +54,7 @@ class InvitationsModel : public QStandardItemModel
     void initializeModel();
 
     bool mModelIsLoading;
+    bool mFetchFromServer = true;
     MerginApi *mApi = nullptr; // not owned
 };
 

--- a/app/invitationsproxymodel.cpp
+++ b/app/invitationsproxymodel.cpp
@@ -24,6 +24,11 @@ bool InvitationsProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex &
   QModelIndex sourceIndex = sourceModel()->index( sourceRow, 0, sourceParent );
   QDateTime expiration = sourceModel()->data( sourceIndex, Qt::StatusTipRole ).toDateTime();
 
+  if ( !expiration.isValid() )
+  {
+    return true;
+  }
+
   return expiration > QDateTime::currentDateTimeUtc();
 }
 

--- a/app/qml/ManageInvitationsPage.qml
+++ b/app/qml/ManageInvitationsPage.qml
@@ -86,10 +86,10 @@ Page {
         Repeater {
           id: invRepeater
 
-          // TODO: change model to userInfo -> invitations
           model: InvitationsProxyModel {
             invitationsSourceModel: InvitationsModel {
               merginApi: __merginApi
+              fetchFromServer: false
             }
           }
 

--- a/app/qml/editor/inputrangeeditable.qml
+++ b/app/qml/editor/inputrangeeditable.qml
@@ -88,6 +88,7 @@ AbstractEditor {
         onTextEdited: {
           let val = text.replace( ",", "." ).replace( / /g, '' ) // replace comma with dot
 
+/*
           let endsWithDecimalSeparator = val.endsWith('.');
           let hasOnlyOneDecimalSeparator = val.split('.').length === 2;
 
@@ -95,6 +96,7 @@ AbstractEditor {
           {
             return; // do not send value changed signal when number ends with decimal separator
           }
+*/
 
           root.editorValueChanged( val, val  === "" )
         }

--- a/app/qml/editor/inputrangeeditable.qml
+++ b/app/qml/editor/inputrangeeditable.qml
@@ -88,16 +88,6 @@ AbstractEditor {
         onTextEdited: {
           let val = text.replace( ",", "." ).replace( / /g, '' ) // replace comma with dot
 
-/*
-          let endsWithDecimalSeparator = val.endsWith('.');
-          let hasOnlyOneDecimalSeparator = val.split('.').length === 2;
-
-          if ( endsWithDecimalSeparator && hasOnlyOneDecimalSeparator )
-          {
-            return; // do not send value changed signal when number ends with decimal separator
-          }
-*/
-
           root.editorValueChanged( val, val  === "" )
         }
 

--- a/app/qml/editor/inputtextedit.qml
+++ b/app/qml/editor/inputtextedit.qml
@@ -66,14 +66,6 @@ AbstractEditor {
       if ( field.isNumeric )
       {
         val = val.replace( ",", "." ).replace( / /g, '' ) // replace comma with dot and remove spaces
-
-        let endsWithDecimalSeparator = val.endsWith('.');
-        let hasOnlyOneDecimalSeparator = val.split('.').length === 2;
-
-        if ( endsWithDecimalSeparator && hasOnlyOneDecimalSeparator )
-        {
-          return; // do not send value changed signal when number ends with decimal separator
-        }
       }
 
       editorValueChanged( val, val === "" )

--- a/app/qml/form/FeatureForm.qml
+++ b/app/qml/form/FeatureForm.qml
@@ -495,7 +495,7 @@ Item {
             height: childrenRect.height
             anchors { left: placeholder.left; right: placeholder.right }
 
-            property var value: AttributeValue
+            property var value: RawValue
             property bool valueIsNull: AttributeValueIsNull
 
             property var field: Field

--- a/app/test/testattributecontroller.cpp
+++ b/app/test/testattributecontroller.cpp
@@ -355,7 +355,6 @@ void TestAttributeController::testValidationMessages()
     QVariant value;
     QString expectedValidationMessage;
     FieldValidator::ValidationStatus expectedValidationStatus;
-    bool canSetValue;
   };
 
   namespace V = ValidationTexts;
@@ -363,80 +362,70 @@ void TestAttributeController::testValidationMessages()
   QList<testunit> testunits
   {
     // Attribute - Name Not NULL - SOFT
-    { items.at( 1 ), QVariant(), V::softNotNullFailed, FieldValidator::Warning, true  },
-    { items.at( 1 ), QStringLiteral( "A" ), "", FieldValidator::Valid, true },
-    { items.at( 1 ), QVariant( QString() ), V::softNotNullFailed, FieldValidator::Warning, true },
-    { items.at( 1 ), "abcsd fsdkajf nsa ", "", FieldValidator::Valid, true },
+    { items.at( 1 ), QVariant(), V::softNotNullFailed, FieldValidator::Warning  },
+    { items.at( 1 ), QStringLiteral( "A" ), "", FieldValidator::Valid },
+    { items.at( 1 ), QVariant( QString() ), V::softNotNullFailed, FieldValidator::Warning },
+    { items.at( 1 ), "abcsd fsdkajf nsa ", "", FieldValidator::Valid },
 
     // Attribute - Size Not NULL - HARD <0; 10000>
-    { items.at( 2 ), QVariant(), V::hardNotNullFailed, FieldValidator::Error, true },
-    { items.at( 2 ), "1", "", FieldValidator::Valid, true },
-    { items.at( 2 ), "1a", V::numberInvalid, FieldValidator::Error, false },
-    { items.at( 2 ), "10001", V::numberUpperBoundReached.arg( 10000 ), FieldValidator::Error, true },
-    { items.at( 2 ), "-1", V::numberLowerBoundReached.arg( 0 ), FieldValidator::Error, true },
-    { items.at( 2 ), "150", "", FieldValidator::Valid, true },
+    { items.at( 2 ), QVariant(), V::hardNotNullFailed, FieldValidator::Error },
+    { items.at( 2 ), "1", "", FieldValidator::Valid },
+    { items.at( 2 ), "1a", V::numberInvalid, FieldValidator::Error },
+    { items.at( 2 ), "10001", V::numberUpperBoundReached.arg( 10000 ), FieldValidator::Error },
+    { items.at( 2 ), "-1", V::numberLowerBoundReached.arg( 0 ), FieldValidator::Error },
+    { items.at( 2 ), "150", "", FieldValidator::Valid },
 
     // Attribute - SectorId Unique - SOFT <-100; 1000>
-    { items.at( 3 ), "1", "", FieldValidator::Valid, true },
-    { items.at( 3 ), "-100", "", FieldValidator::Valid, true },
-    { items.at( 3 ), "13", V::softUniqueFailed, FieldValidator::Warning, true }, // there should already be feature with such value
-    { items.at( 3 ), "14", "", FieldValidator::Valid, true },
-    { items.at( 3 ), "14sad", V::numberInvalid, FieldValidator::Error, false },
-    { items.at( 3 ), "14", "", FieldValidator::Valid, true },
+    { items.at( 3 ), "1", "", FieldValidator::Valid },
+    { items.at( 3 ), "-100", "", FieldValidator::Valid },
+    { items.at( 3 ), "13", V::softUniqueFailed, FieldValidator::Warning }, // there should already be feature with such value
+    { items.at( 3 ), "14", "", FieldValidator::Valid },
+    { items.at( 3 ), "14sad", V::numberInvalid, FieldValidator::Error },
+    { items.at( 3 ), "14", "", FieldValidator::Valid },
 
     // Attribute - Occupied Expression, must be TRUE - HARD, expression descriptionn: 'Must be true'
-    { items.at( 4 ), false, QStringLiteral( "Must be true" ), FieldValidator::Error, true },
-    { items.at( 4 ), true, "", FieldValidator::Valid, true },
+    { items.at( 4 ), false, QStringLiteral( "Must be true" ), FieldValidator::Error },
+    { items.at( 4 ), true, "", FieldValidator::Valid },
 
     // Attribure - DateTime(datetime) Not NULL - HARD, format: yyyy-MM-dd HH:mm:ss (default)
-    { items.at( 5 ), QVariant(), V::hardNotNullFailed, FieldValidator::Error, true },
-    { items.at( 5 ), QVariant( QDateTime::fromString( "2020-03-10 10:40:30", "yyyy-MM-dd HH:mm:ss" ) ), "", FieldValidator::Valid, true },
+    { items.at( 5 ), QVariant(), V::hardNotNullFailed, FieldValidator::Error },
+    { items.at( 5 ), QVariant( QDateTime::fromString( "2020-03-10 10:40:30", "yyyy-MM-dd HH:mm:ss" ) ), "", FieldValidator::Valid },
 
     // Attribure - LastEdit(date) Not NULL - HARD, format: dd-MM-yyyy (custom)
-    { items.at( 6 ), QVariant(), V::hardNotNullFailed, FieldValidator::Error, true },
-    { items.at( 6 ), QVariant( QDateTime::fromString( "29-10-1998", "dd-MM-yyyy" ) ), "", FieldValidator::Valid, true },
+    { items.at( 6 ), QVariant(), V::hardNotNullFailed, FieldValidator::Error },
+    { items.at( 6 ), QVariant( QDateTime::fromString( "29-10-1998", "dd-MM-yyyy" ) ), "", FieldValidator::Valid },
 
     // Attribute - Hash Unique - HARD
-    { items.at( 7 ), QVariant(), "", FieldValidator::Valid, true },
-    { items.at( 7 ), "1", V::hardUniqueFailed, FieldValidator::Error, true },
-    { items.at( 7 ), QVariant(), "", FieldValidator::Valid, true },
-    { items.at( 7 ), "2", "", FieldValidator::Valid, true },
+    { items.at( 7 ), QVariant(), "", FieldValidator::Valid },
+    { items.at( 7 ), "1", V::hardUniqueFailed, FieldValidator::Error },
+    { items.at( 7 ), QVariant(), "", FieldValidator::Valid },
+    { items.at( 7 ), "2", "", FieldValidator::Valid },
 
     // Attribute - Code Length limit 5
-    { items.at( 8 ), "", "", FieldValidator::Valid, true },
-    { items.at( 8 ), "f", "", FieldValidator::Valid, true },
-    { items.at( 8 ), "fi", "", FieldValidator::Valid, true },
-    { items.at( 8 ), "five ", "", FieldValidator::Valid, true },
-    { items.at( 8 ), "five chars limit", V::textTooLong.arg( 5 ), FieldValidator::Error, false },
-    { items.at( 8 ), "five ", "", FieldValidator::Valid, true }
+    { items.at( 8 ), "", "", FieldValidator::Valid },
+    { items.at( 8 ), "f", "", FieldValidator::Valid },
+    { items.at( 8 ), "fi", "", FieldValidator::Valid },
+    { items.at( 8 ), "five ", "", FieldValidator::Valid },
+    { items.at( 8 ), "five chars limit", V::textTooLong.arg( 5 ), FieldValidator::Error },
+    { items.at( 8 ), "five ", "", FieldValidator::Valid }
   };
 
   for ( const testunit &unit : testunits )
   {
     const FormItem *item = controller.formItem( unit.id );
+    controller.setFormValue( unit.id, unit.value );
 
-    bool res = controller.setFormValue( unit.id, unit.value );
-
-    if ( !res )
-    {
-      QCOMPARE( res, unit.canSetValue );
-    }
-    else
-    {
-      QCOMPARE( item->validationMessage(), unit.expectedValidationMessage );
-      QCOMPARE( item->validationStatus(), unit.expectedValidationStatus );
-    }
+    QCOMPARE( item->validationMessage(), unit.expectedValidationMessage );
+    QCOMPARE( item->validationStatus(), unit.expectedValidationStatus );
   }
 
   QCOMPARE( controller.hasValidationErrors(), false );
 
   // invalidate some attribute and check if hasValidationErrors responds correctly
-  bool res = controller.setFormValue( items.at( 8 ), "five chars limit" );
-  QCOMPARE( res, false );
-  QCOMPARE( controller.hasValidationErrors(), false );
+  controller.setFormValue( items.at( 8 ), "five chars limit" );
+  QCOMPARE( controller.hasValidationErrors(), true );
 
-  res = controller.setFormValue( items.at( 8 ), "five " );
-  QCOMPARE( res, true );
+  controller.setFormValue( items.at( 8 ), "five " );
   QCOMPARE( controller.hasValidationErrors(), false );
 
   // Try assigning different features and values to see if the state is reseted

--- a/app/test/testattributecontroller.h
+++ b/app/test/testattributecontroller.h
@@ -28,6 +28,7 @@ class TestAttributeController: public QObject
     void tabsAndFieldsMixed();
     void testValidationMessages();
     void testExpressions();
+    void testRawValue();
 };
 
 #endif // TESTATTRIBUTECONTROLLER_H

--- a/app/test/testformeditors.cpp
+++ b/app/test/testformeditors.cpp
@@ -94,7 +94,6 @@ void TestFormEditors::testNumericFields()
     QUuid fieldUuid;
     QString expectedValidationMessage;
     FieldValidator::ValidationStatus expectedValidationStatus;
-    bool canSetValue;
   };
 
   namespace V = ValidationTexts;
@@ -102,76 +101,70 @@ void TestFormEditors::testNumericFields()
   QList<combination> combinations =
   {
     // field "Heading", Int, range <100; 1000>, range editable
-    { QVariant( QString() ), headingFieldId, "", FieldValidator::Valid, true },
-    { "1", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error, true },
-    { "-1", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error, true },
-    { "10", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error, true },
-    { "-10", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error, true },
-    { "-100", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error, true },
-    { "100", headingFieldId, "", FieldValidator::Valid, true },
-    { "100h", headingFieldId, V::numberInvalid, FieldValidator::Error, false },
-    { "100", headingFieldId, "", FieldValidator::Valid, true },
-    { "1001", headingFieldId, V::numberUpperBoundReached.arg( 1000 ), FieldValidator::Error, true },
-    { "1000", headingFieldId, "", FieldValidator::Valid, true },
+    { QVariant( QString() ), headingFieldId, "", FieldValidator::Valid },
+    { "1", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error },
+    { "-1", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error },
+    { "10", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error },
+    { "-10", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error },
+    { "-100", headingFieldId, V::numberLowerBoundReached.arg( 100 ), FieldValidator::Error },
+    { "100", headingFieldId, "", FieldValidator::Valid },
+    { "100h", headingFieldId, V::numberInvalid, FieldValidator::Error },
+    { "100", headingFieldId, "", FieldValidator::Valid },
+    { "1001", headingFieldId, V::numberUpperBoundReached.arg( 1000 ), FieldValidator::Error },
+    { "1000", headingFieldId, "", FieldValidator::Valid },
 
     // field "Importance", Real, range <-100.00; 100.00>, step:0.01, precision: 2, range editable
-    { QVariant( QString() ), importanceFieldId, "", FieldValidator::Valid, true },
-    { "0", importanceFieldId, "", FieldValidator::Valid, true },
-    { "-1.00", importanceFieldId, "", FieldValidator::Valid, true },
-    { "100.00", importanceFieldId, "", FieldValidator::Valid, true },
-    { "100.002", importanceFieldId, V::numberUpperBoundReached.arg( 100.00 ), FieldValidator::Error, true },
-    { "100.002fdsa", importanceFieldId, V::numberInvalid, FieldValidator::Error, false },
-    { "100.,.,.,", importanceFieldId, V::numberInvalid, FieldValidator::Error, false },
-    { "1 000", importanceFieldId, V::numberInvalid, FieldValidator::Error, false },
-    { "10", importanceFieldId, "", FieldValidator::Valid, true },
+    { QVariant( QString() ), importanceFieldId, "", FieldValidator::Valid },
+    { "0", importanceFieldId, "", FieldValidator::Valid },
+    { "-1.00", importanceFieldId, "", FieldValidator::Valid },
+    { "100.00", importanceFieldId, "", FieldValidator::Valid },
+    { "100.002", importanceFieldId, V::numberUpperBoundReached.arg( 100.00 ), FieldValidator::Error },
+    { "100.002fdsa", importanceFieldId, V::numberInvalid, FieldValidator::Error },
+    { "100.,.,.,", importanceFieldId, V::numberInvalid, FieldValidator::Error },
+    { "1 000", importanceFieldId, V::numberInvalid, FieldValidator::Error },
+    { "10", importanceFieldId, "", FieldValidator::Valid },
 
     // field "Pilots", Int, range <-1000; -100>, range editable
-    { QVariant( QString() ), pilotsFieldId, "", FieldValidator::Valid, true },
-    { "-100", pilotsFieldId, "", FieldValidator::Valid, true },
-    { "-1000", pilotsFieldId, "", FieldValidator::Valid, true },
-    { "0", pilotsFieldId, V::numberUpperBoundReached.arg( -100 ), FieldValidator::Error, true },
-    { "150", pilotsFieldId, V::numberUpperBoundReached.arg( -100 ), FieldValidator::Error, true },
-    { "-1001", pilotsFieldId, V::numberLowerBoundReached.arg( -1000 ), FieldValidator::Error, true },
-    { "-51216354321435", pilotsFieldId, V::numberExceedingVariableLimits, FieldValidator::Error, false },
-    { "--100", pilotsFieldId, V::numberInvalid, FieldValidator::Error, false },
-    { "--100fsda", pilotsFieldId, V::numberInvalid, FieldValidator::Error, false },
-    { "-100", pilotsFieldId, "", FieldValidator::Valid, true },
+    { QVariant( QString() ), pilotsFieldId, "", FieldValidator::Valid },
+    { "-100", pilotsFieldId, "", FieldValidator::Valid },
+    { "-1000", pilotsFieldId, "", FieldValidator::Valid },
+    { "0", pilotsFieldId, V::numberUpperBoundReached.arg( -100 ), FieldValidator::Error },
+    { "150", pilotsFieldId, V::numberUpperBoundReached.arg( -100 ), FieldValidator::Error },
+    { "-1001", pilotsFieldId, V::numberLowerBoundReached.arg( -1000 ), FieldValidator::Error },
+    { "-51216354321435", pilotsFieldId, V::numberExceedingVariableLimits, FieldValidator::Error },
+    { "--100", pilotsFieldId, V::numberInvalid, FieldValidator::Error },
+    { "--100fsda", pilotsFieldId, V::numberInvalid, FieldValidator::Error },
+    { "-100", pilotsFieldId, "", FieldValidator::Valid },
 
     // field "Cabin Crew", Int, no limit, range editable
-    { QVariant( QString() ), cabinCrewFieldId, "", FieldValidator::Valid, true },
-    { "-100", cabinCrewFieldId, "", FieldValidator::Valid, true },
-    { "-1000", cabinCrewFieldId, "", FieldValidator::Valid, true },
-    { "-2147483647", cabinCrewFieldId, "", FieldValidator::Valid, true }, // int limit from QGIS
-    { "2147483647", cabinCrewFieldId, "", FieldValidator::Valid, true }, // int limit from QGIS
-    { "214748364799", cabinCrewFieldId, V::numberExceedingVariableLimits, FieldValidator::Error, false },
-    { "-214748364799", cabinCrewFieldId, V::numberExceedingVariableLimits, FieldValidator::Error, false },
-    { "-214748-", cabinCrewFieldId, V::numberInvalid, FieldValidator::Error, false },
+    { QVariant( QString() ), cabinCrewFieldId, "", FieldValidator::Valid },
+    { "-100", cabinCrewFieldId, "", FieldValidator::Valid },
+    { "-1000", cabinCrewFieldId, "", FieldValidator::Valid },
+    { "-2147483647", cabinCrewFieldId, "", FieldValidator::Valid }, // int limit from QGIS
+    { "2147483647", cabinCrewFieldId, "", FieldValidator::Valid }, // int limit from QGIS
+    { "214748364799", cabinCrewFieldId, V::numberExceedingVariableLimits, FieldValidator::Error },
+    { "-214748364799", cabinCrewFieldId, V::numberExceedingVariableLimits, FieldValidator::Error },
+    { "-214748-", cabinCrewFieldId, V::numberInvalid, FieldValidator::Error },
 
     // field "Staff", Int, no limit, range slider
-    { QVariant( QString() ), staffFieldId, "", FieldValidator::Valid, true },
-    { "10", staffFieldId, "", FieldValidator::Valid, true },
-    { "-10", staffFieldId, "", FieldValidator::Valid, false },
+    { QVariant( QString() ), staffFieldId, "", FieldValidator::Valid },
+    { "10", staffFieldId, "", FieldValidator::Valid },
+    { "-10", staffFieldId, "", FieldValidator::Valid },
     // QML Slider does not allow to enter values higher or lower than specified range
   };
 
   // compare results
   for ( const auto &c : combinations )
   {
+    controller.setFormValue( c.fieldUuid, c.value );
     const FormItem *item = controller.formItem( c.fieldUuid );
-    bool res = controller.setFormValue( c.fieldUuid, c.value );
 
-    if ( !res )
-    {
-      QCOMPARE( res, c.canSetValue );
-    }
-    else
-    {
-      QCOMPARE( item->validationMessage(), c.expectedValidationMessage );
-      QCOMPARE( item->validationStatus(), c.expectedValidationStatus );
-    }
+    QCOMPARE( item->validationMessage(), c.expectedValidationMessage );
+    QCOMPARE( item->validationStatus(), c.expectedValidationStatus );
   }
 
-  QCOMPARE( controller.hasValidationErrors(), false );
+  // field "Cabin Crew" stayed with invalid input, check controller flag of values validity
+  QCOMPARE( controller.hasValidationErrors(), true );
 
   // invalidate some attribute and check if hasValidationErrors responds correctly
   controller.setFormValue( cabinCrewFieldId, "100" );


### PR DESCRIPTION
Bring back field validations by storing value entered by the user as a "raw" value and running validations against this value instead of using value converted to the compatible form for the field.