### PR TITLE
Do not retrieve child features if parent feature is invalid

### DIFF
--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -31,6 +31,15 @@ Item {
     relation: associatedRelation
     parentFeatureLayerPair: featurePair
     homePath: activeProject.homePath
+
+    onModelReset: {
+      // Repeater does not necesarry clear delegates immediately if they are invisible,
+      // we need to do hard reload in this case so that recalculateVisibleItems() is triggered
+      generator.model = null
+      generator.model = rmodel
+
+      generator.recalculateVisibleItems()
+    }
   }
 
   anchors {

--- a/app/qml/editor/inputrelationreference.qml
+++ b/app/qml/editor/inputrelationreference.qml
@@ -100,7 +100,7 @@ AbstractEditor {
         root.parent.formView.pop()
       }
 
-      onSelectionFinished: {
+      onSelectionFinished: function( featureIds ) {
         let fk = rModel.foreignKeyFromAttribute( FeaturesModel.FeatureId, featureIds )
         root.editorValueChanged( fk, false )
         root.parent.formView.pop()

--- a/app/relationfeaturesmodel.cpp
+++ b/app/relationfeaturesmodel.cpp
@@ -67,11 +67,24 @@ void RelationFeaturesModel::setupFeatureRequest( QgsFeatureRequest &request )
 
 void RelationFeaturesModel::setParentFeatureLayerPair( FeatureLayerPair pair )
 {
-  if ( mParentFeatureLayerPair != pair )
-  {
-    mParentFeatureLayerPair = pair;
-    emit parentFeatureLayerPairChanged( mParentFeatureLayerPair );
+  if ( mParentFeatureLayerPair == pair )
+    return;
 
+  mParentFeatureLayerPair = pair;
+  emit parentFeatureLayerPairChanged( mParentFeatureLayerPair );
+
+  if ( !InputUtils::isFeatureIdValid( pair.feature().id() ) )
+  {
+    //
+    // Clear the model in case parent feature has invalid id (e.g. is new) and do not populate it
+    //
+
+    beginResetModel();
+    reset();
+    endResetModel();
+  }
+  else
+  {
     setup();
   }
 }


### PR DESCRIPTION
3 minor issues were fixed with help of @alexbruy : 
- `Repeater` (generator) component for an unknown reason does not detect model reset (it probably does not bother destroying delegates that are invisible immediately). This had consequences like "x more" button in a relations widget being visible even if there were no child features
- another parameter injection
- do not request child features if a parent feature id is not valid yet (when it is new: <0). QGIS API returns some random values then

Note: do not believe the commit message, it is an ugly lie (it does not fix the issue, #2548 will)