### PR TITLE
Disable HTTP/2 requests to work around a networking bug

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -31,6 +31,7 @@
 #include "qgsconfig.h"
 #include "qgsproviderregistry.h"
 #include "qgsmaplayerproxymodel.h"
+#include "qgsnetworkaccessmanager.h"
 
 #include "androidutils.h"
 #include "ios/iosutils.h"
@@ -473,6 +474,13 @@ int main( int argc, char *argv[] )
     as.setDemoProjectsCopied( true );
     hasLoadedDemoProjects = true;
   }
+
+  // there seem to be issues with HTTP/2 server support (QTBUG-111417)
+  // so let's stick to HTTP/1 for the time being (Qt5 has HTTP/2 disabled by default)
+  QgsNetworkAccessManager::instance()->setRequestPreprocessor( []( QNetworkRequest * r )
+  {
+    r->setAttribute( QNetworkRequest::Http2AllowedAttribute, false );
+  } );
 
   // Create Input classes
   AndroidUtils au;


### PR DESCRIPTION
Fixes #2572 

Qt5 has HTTP/2 disabled by default, Qt6 has HTTP/2 enabled by default.

Users have reported that WMS server of Danish SDFI is not working anymore and it turns out it is due to a bug in Qt ([QTBUG-111417](https://bugreports.qt.io/browse/QTBUG-111417)) so let's avoid HTTP/2 for the time being.