### PR TITLE
add an active workspace id to the subscription url

### DIFF
--- a/app/purchasing.cpp
+++ b/app/purchasing.cpp
@@ -276,6 +276,19 @@ void Purchasing::onHasInAppPurchasesChanged()
   setSubscriptionBillingUrl( subscriptionBillingUrl );
 }
 
+QString Purchasing::subscriptionUrlWithWorkspace()
+{
+  int ws = mMerginApi->userInfo()->activeWorkspaceId();
+  if ( ws >= 0 )
+  {
+    return mSubscriptionManageUrl + QStringLiteral( "?workspace=%1" ).arg( ws );
+  }
+  else
+  {
+    return mSubscriptionManageUrl;
+  }
+}
+
 bool Purchasing::hasInAppPurchases() const
 {
   return mHasInAppPurchases;
@@ -665,15 +678,7 @@ void Purchasing::setSubscriptionBillingUrl( const QString &subscriptionBillingUr
 
 void Purchasing::setDefaultUrls()
 {
-  int ws = mMerginApi->userInfo()->activeWorkspaceId();
-  if ( ws >= 0 )
-  {
-    mSubscriptionManageUrl = mMerginApi->apiRoot() + QStringLiteral( "subscription?workspace=%1" ).arg( ws );
-  }
-  else
-  {
-    mSubscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
-  }
+  mSubscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
   emit subscriptionManageUrlChanged();
   mSubscriptionBillingUrl = mMerginApi->apiRoot() + "billing";
   emit subscriptionBillingUrlChanged();

--- a/app/purchasing.cpp
+++ b/app/purchasing.cpp
@@ -252,7 +252,16 @@ void Purchasing::evaluateHasInAppPurchases()
 void Purchasing::onHasInAppPurchasesChanged()
 {
   bool hasManageCapability = false;
-  QString subscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
+  int ws = mMerginApi->userInfo()->activeWorkspaceId();
+  QString subscriptionManageUrl;
+  if ( ws >= 0 )
+  {
+    subscriptionManageUrl = mMerginApi->apiRoot() + QStringLiteral( "subscription?workspace=%1" ).arg( ws );
+  }
+  else
+  {
+    subscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
+  }
   QString subscriptionBillingUrl = mMerginApi->apiRoot() + "billing";
 
   if ( hasInAppPurchases() )
@@ -656,7 +665,15 @@ void Purchasing::setSubscriptionBillingUrl( const QString &subscriptionBillingUr
 
 void Purchasing::setDefaultUrls()
 {
-  mSubscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
+  int ws = mMerginApi->userInfo()->activeWorkspaceId();
+  if ( ws >= 0 )
+  {
+    mSubscriptionManageUrl = mMerginApi->apiRoot() + QStringLiteral( "subscription?workspace=%1" ).arg( ws );
+  }
+  else
+  {
+    mSubscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
+  }
   emit subscriptionManageUrlChanged();
   mSubscriptionBillingUrl = mMerginApi->apiRoot() + "billing";
   emit subscriptionBillingUrlChanged();

--- a/app/purchasing.cpp
+++ b/app/purchasing.cpp
@@ -252,16 +252,7 @@ void Purchasing::evaluateHasInAppPurchases()
 void Purchasing::onHasInAppPurchasesChanged()
 {
   bool hasManageCapability = false;
-  int ws = mMerginApi->userInfo()->activeWorkspaceId();
-  QString subscriptionManageUrl;
-  if ( ws >= 0 )
-  {
-    subscriptionManageUrl = mMerginApi->apiRoot() + QStringLiteral( "subscription?workspace=%1" ).arg( ws );
-  }
-  else
-  {
-    subscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
-  }
+  QString subscriptionManageUrl = mMerginApi->apiRoot() + "subscription";
   QString subscriptionBillingUrl = mMerginApi->apiRoot() + "billing";
 
   if ( hasInAppPurchases() )

--- a/app/purchasing.h
+++ b/app/purchasing.h
@@ -246,7 +246,6 @@ class Purchasing : public QObject
     Q_PROPERTY( bool hasInAppPurchases READ hasInAppPurchases NOTIFY hasInAppPurchasesChanged )
     Q_PROPERTY( bool hasManageSubscriptionCapability READ hasManageSubscriptionCapability NOTIFY hasManageSubscriptionCapabilityChanged )
     Q_PROPERTY( QString subscriptionManageUrl READ subscriptionManageUrl NOTIFY subscriptionManageUrlChanged )
-    Q_PROPERTY( QString subscriptionManageUrl READ subscriptionManageUrl NOTIFY subscriptionManageUrlChanged )
     Q_PROPERTY( QString subscriptionBillingUrl READ subscriptionBillingUrl NOTIFY subscriptionBillingUrlChanged )
 
   public:

--- a/app/purchasing.h
+++ b/app/purchasing.h
@@ -246,6 +246,7 @@ class Purchasing : public QObject
     Q_PROPERTY( bool hasInAppPurchases READ hasInAppPurchases NOTIFY hasInAppPurchasesChanged )
     Q_PROPERTY( bool hasManageSubscriptionCapability READ hasManageSubscriptionCapability NOTIFY hasManageSubscriptionCapabilityChanged )
     Q_PROPERTY( QString subscriptionManageUrl READ subscriptionManageUrl NOTIFY subscriptionManageUrlChanged )
+    Q_PROPERTY( QString subscriptionManageUrl READ subscriptionManageUrl NOTIFY subscriptionManageUrlChanged )
     Q_PROPERTY( QString subscriptionBillingUrl READ subscriptionBillingUrl NOTIFY subscriptionBillingUrlChanged )
 
   public:
@@ -253,6 +254,7 @@ class Purchasing : public QObject
 
     Q_INVOKABLE void purchase( const QString &planId );
     Q_INVOKABLE void restore();
+    Q_INVOKABLE QString subscriptionUrlWithWorkspace();
 
     bool hasManageSubscriptionCapability() const;
     bool transactionPending() const;

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -51,7 +51,7 @@ Item {
       }
     }
     else {
-      Qt.openUrlExternally(__purchasing.subscriptionManageUrl);
+      Qt.openUrlExternally(__purchasing.subscriptionUrlWithWorkspace());
     }
   }
 


### PR DESCRIPTION
Adds `?workspace=` query parameter to the subscriptions URL.