### PR TITLE
SSL error on windows

### DIFF
--- a/cmake/InstallStep.cmake
+++ b/cmake/InstallStep.cmake
@@ -134,6 +134,7 @@ set(plugins_dirs
     imageformats
     platforms
     multimedia
+    tls
 )
 
 foreach (plugins_dir ${plugins_dirs})


### PR DESCRIPTION
fix #2563

TLS plugin was missing in the installation on windows (and lnx and macos, but we do not package/ship there and in development you use lib from QT's installation)