### PR TITLE
Rename android artifacts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -249,7 +249,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
-          name: APK compined
+          name: Mergin Maps ${{ env.INPUT_VERSION_CODE }} APK [v7 + v8a]
 
       - name: build AAB
         if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
@@ -277,5 +277,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.aab
-          name: AAB bundle
+          name: Mergin Maps ${{ env.INPUT_VERSION_CODE }} AAB
           


### PR DESCRIPTION
Renames Android artifacts so that one knows which version he/she downloads.
Having a common name without version becomes an issue if you download 20 different versions 🙂 

<img width="743" alt="image" src="https://user-images.githubusercontent.com/22449698/223977235-be1af3da-1586-46b3-b0c2-f489d4a8dd3a.png">
