### PR TITLE
fix endless spinner in project list

### DIFF
--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -351,7 +351,9 @@ Item {
           }
         ]
 
-        state: "local"
+        Component.onCompleted: {
+          pageContent.state = "local"
+        }
 
         onStateChanged: {
           __merginApi.pingMergin()
@@ -672,7 +674,9 @@ Item {
           }
         ]
 
-        state: "local"
+        Component.onCompleted: {
+          pageContent.state = "local"
+        }
 
         onStateChanged: {
           __merginApi.pingMergin()

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -351,10 +351,6 @@ Item {
           }
         ]
 
-        Component.onCompleted: {
-          pageContent.state = "local"
-        }
-
         onStateChanged: {
           __merginApi.pingMergin()
           projectsPage.refreshProjectList()
@@ -673,10 +669,6 @@ Item {
             name: "public"
           }
         ]
-
-        Component.onCompleted: {
-          pageContent.state = "local"
-        }
 
         onStateChanged: {
           __merginApi.pingMergin()


### PR DESCRIPTION
Setting state directly does not work as expected, reverting back to use `onCompleted`.