### PR TITLE
fixes #2632

### DIFF
--- a/app/qml/form/PreviewPanel.qml
+++ b/app/qml/form/PreviewPanel.qml
@@ -172,6 +172,7 @@ Item {
                     source: controller.photo
                     sourceSize: Qt.size(width, height)
                     fillMode: Image.PreserveAspectFit
+                    autoTransform : true
                     anchors.fill: parent
                     anchors.topMargin: InputStyle.panelMargin
                 }


### PR DESCRIPTION
Since qt 6.2, it is possible to use autotransform to change the photo orientation:
https://doc.qt.io/qt-6.2/qml-qtquick-image.html#autoTransform-prop

This should fix the image orientation issue in the preview panel.