### PR TITLE
generate debug symbols in AAB

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -82,5 +82,6 @@ android {
         minSdkVersion qtMinSdkVersion
         targetSdkVersion qtTargetSdkVersion
         ndk.abiFilters = qtTargetAbiList.split(",")
+        ndk.debugSymbolLevel "FULL"
     }
 }


### PR DESCRIPTION
fixes https://github.com/MerginMaps/input/issues/2147

- for APK there is file: `build-input-android/app/android-build/build/outputs/native-debug-symbols/debug/native-debug-symbols.zip` which has `29M`
- AAB in `build-input-android/app/android-build/build/outputs/bundle/release/android-build-release.aab` has now `561M`
- AAB now contains files like
``` 
BUNDLE-METADATA/com.android.tools.build.debugsymbols/arm64-v8a$ find . | grep -i input
./libInput_arm64-v8a.so.dbg
``` 

limit is 300MB based on https://developer.android.com/studio/build/shrink-code#strip-native-libraries, but I hope for symbols file, so it should be fine?

I am not sure how to test it, symbols are now part of AAB, but probably for testing we need to somehow upload it to google play and test in there in some betatesting build? @tomasMizera 