### PR TITLE
fix endless spinner in the project panel

### DIFF
--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -600,6 +600,11 @@ Item {
           case "local":
             localProjectsPage.refreshProjectsList( keepSearchFilter )
             break
+          case "":
+            // seems onVisibleChanged is not called on Android and state
+            // is not set when panel created.
+            localProjectsPage.refreshProjectsList( keepSearchFilter )
+            break
           case "created":
             workspaceProjectsPage.refreshProjectsList( keepSearchFilter )
             break
@@ -680,7 +685,6 @@ Item {
           // has more than one ws and has not seen it yet for too many times
           //
           if ( state === "created" ) {
-
             if (__merginApi.apiSupportsWorkspaces &&
                 __merginApi.userInfo.hasMoreThanOneWorkspace &&
                 !__appSettings.ignoreWsTooltip ) {

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -351,8 +351,6 @@ Item {
           }
         ]
 
-        state: "local"
-
         onStateChanged: {
           __merginApi.pingMergin()
           projectsPage.refreshProjectList()
@@ -671,8 +669,6 @@ Item {
             name: "public"
           }
         ]
-
-        state: "local"
 
         onStateChanged: {
           __merginApi.pingMergin()


### PR DESCRIPTION
Do not set state for project panel explicitly as this prevents fetching/refreshing project list on the first load of the component.