### PR TITLE
do not show what's new dialog and remove corresponding setting

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -34,7 +34,6 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   bool legacyFolderMigrated = settings.value( QStringLiteral( "legacyFolderMigrated" ), false ).toBool();
   QString activeProviderId = settings.value( QStringLiteral( "activePositionProviderId" ) ).toString();
   bool autosync = settings.value( QStringLiteral( "autosyncAllowed" ), false ).toBool();
-  bool ignoreWhatsNew = settings.value( QStringLiteral( "ignoreWhatsNew" ), false ).toBool();
   mWsTooltipShownCounter = settings.value( QStringLiteral( "wsTooltipCounter" ) ).toInt();
   double gpsHeight = settings.value( "gpsHeight", 0 ).toDouble();
 
@@ -53,7 +52,6 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   setLegacyFolderMigrated( legacyFolderMigrated );
   setActivePositionProviderId( activeProviderId );
   setAutosyncAllowed( autosync );
-  setIgnoreWhatsNew( ignoreWhatsNew );
   setGpsAntennaHeight( gpsHeight );
 }
 
@@ -345,21 +343,6 @@ void AppSettings::setAutosyncAllowed( bool newAutosyncAllowed )
   mAutosyncAllowed = newAutosyncAllowed;
   setValue( QStringLiteral( "autosyncAllowed" ), newAutosyncAllowed );
   emit autosyncAllowedChanged( mAutosyncAllowed );
-}
-
-bool AppSettings::ignoreWhatsNew() const
-{
-  return mIgnoreWhatsNew;
-}
-
-void AppSettings::setIgnoreWhatsNew( bool newIgnoreWhatsNew )
-{
-  if ( mIgnoreWhatsNew == newIgnoreWhatsNew )
-    return;
-
-  mIgnoreWhatsNew = newIgnoreWhatsNew;
-  setValue( QStringLiteral( "ignoreWhatsNew" ), newIgnoreWhatsNew );
-  emit ignoreWhatsNewChanged();
 }
 
 void AppSettings::wsTooltipShown()

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -35,7 +35,6 @@ class AppSettings: public QObject
     Q_PROPERTY( bool legacyFolderMigrated READ legacyFolderMigrated WRITE setLegacyFolderMigrated NOTIFY legacyFolderMigratedChanged )
     Q_PROPERTY( QString activePositionProviderId READ activePositionProviderId WRITE setActivePositionProviderId NOTIFY activePositionProviderIdChanged )
     Q_PROPERTY( bool autosyncAllowed READ autosyncAllowed WRITE setAutosyncAllowed NOTIFY autosyncAllowedChanged )
-    Q_PROPERTY( bool ignoreWhatsNew READ ignoreWhatsNew WRITE setIgnoreWhatsNew NOTIFY ignoreWhatsNewChanged )
     Q_PROPERTY( bool ignoreWsTooltip READ ignoreWsTooltip NOTIFY ignoreWsTooltipChanged )
     Q_PROPERTY( double gpsAntennaHeight READ gpsAntennaHeight WRITE setGpsAntennaHeight NOTIFY gpsAntennaHeightChanged )
 
@@ -90,9 +89,6 @@ class AppSettings: public QObject
     bool autosyncAllowed() const;
     void setAutosyncAllowed( bool newAutosyncAllowed );
 
-    bool ignoreWhatsNew() const;
-    void setIgnoreWhatsNew( bool newIgnoreWhatsNew );
-
     double gpsAntennaHeight() const;
     void setGpsAntennaHeight( double gpsAntennaHeight );
 
@@ -123,7 +119,6 @@ class AppSettings: public QObject
     void activePositionProviderIdChanged( const QString & );
 
     void autosyncAllowedChanged( bool autosyncAllowed );
-    void ignoreWhatsNewChanged();
 
     void ignoreWsTooltipChanged(); // ---> can be removed after migration to ws
 
@@ -161,7 +156,6 @@ class AppSettings: public QObject
     QVariant value( const QString &key, const QVariant &defaultValue = QVariant() );
     QString mActivePositionProviderId;
     bool mAutosyncAllowed = false;
-    bool mIgnoreWhatsNew = false;
     int mWsTooltipShownCounter = 0; // ---> can be removed after migration to ws
     double mGpsAntennaHeight = 0;
 };

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -653,17 +653,6 @@ ApplicationWindow {
       }
     }
 
-    WhatsNewDialog {
-      id: whatsNewDialog
-
-      width: parent.width / 2 < InputStyle.minDialogWidth ? parent.width - 2 * InputStyle.panelMargin : parent.width / 2
-      height: parent.height / 2 < InputStyle.minDialogHeight ? parent.height - 2 * InputStyle.panelMargin : parent.height / 2
-
-      anchors.centerIn: parent
-      informativeText: qsTr("We've made it easier for teams to collaborate on Mergin Maps! To find out more, check out our latest blog post about workspaces by clicking the button below.")
-      infoUrl: __inputHelp.whatsNewPostLink
-    }
-
     ProjectLoadingScreen {
       id: projectLoadingScreen
 
@@ -698,12 +687,6 @@ ApplicationWindow {
           //! if current project has been updated, refresh canvas
           if ( projectFullName === projectPanel.activeProjectId ) {
             map.mapSettings.extentChanged()
-          }
-        }
-
-        function onServerWasUpgraded() {
-          if (!__appSettings.ignoreWhatsNew) {
-            whatsNewDialog.open()
           }
         }
     }


### PR DESCRIPTION
As workspaces migration completed we don't need it anymore.