### PR TITLE
Apply Qt6 click propagation fix to desktop builds

### DIFF
--- a/app/qml/map/MapCanvas.qml
+++ b/app/qml/map/MapCanvas.qml
@@ -173,31 +173,6 @@ Item {
     }
   }
 
-  // Mouse, stylus and other pointer devices handler
-  TapHandler {
-    id: stylusClick
-
-    property bool longPressActive: false
-
-    enabled: !mouseAsTouchScreen
-    acceptedDevices: PointerDevice.AllDevices & ~PointerDevice.TouchScreen
-
-    onSingleTapped: {
-      root.clicked(point.position)
-    }
-
-    onLongPressed: {
-      root.longPressed(point.position)
-      longPressActive = true
-    }
-
-    onPressedChanged: {
-      if (longPressActive)
-        root.longPressReleased()
-      longPressActive = false
-    }
-  }
-
   //
   // Qt6.0+ does not work well when PinchHandler is combined with TapHandler.
   // Sometimes, after map is zoomed in/out a few times, TapHandler ends in an invalid state -
@@ -291,6 +266,31 @@ Item {
             dragHandler.grabPermissions = PointerHandler.ApprovesTakeOverByHandlersOfSameType | PointerHandler.ApprovesTakeOverByHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByItems
           }
 
+          if (longPressActive)
+            root.longPressReleased()
+          longPressActive = false
+        }
+      }
+
+      // Mouse, stylus and other pointer devices handler
+      TapHandler {
+        id: stylusClick
+
+        property bool longPressActive: false
+
+        enabled: !mouseAsTouchScreen
+        acceptedDevices: PointerDevice.AllDevices & ~PointerDevice.TouchScreen
+
+        onSingleTapped: {
+          root.clicked(point.position)
+        }
+
+        onLongPressed: {
+          root.longPressed(point.position)
+          longPressActive = true
+        }
+
+        onPressedChanged: {
           if (longPressActive)
             root.longPressReleased()
           longPressActive = false


### PR DESCRIPTION
PR applies the fix ( see https://github.com/MerginMaps/input/pull/2425 ) for map canvas clicks propagation to desktop builds.

-> fixes the issue that feature form closes itself randomly on Windows (and other desktop builds)

Fixes https://github.com/MerginMaps/input/issues/2556