### PR TITLE
Add native iOS CLLocationManager tracking backend

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -498,9 +498,8 @@ if (MACOS OR IOS)
 endif ()
 
 if (IOS)
-    target_link_libraries(
-    Input PUBLIC AppleFrameworks::CoreLocation)
-endif()
+  target_link_libraries(Input PUBLIC AppleFrameworks::CoreLocation)
+endif ()
 
 if (HAVE_APPLE_PURCHASING)
   target_link_libraries(

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -221,7 +221,13 @@ if (ENABLE_TESTS)
 endif ()
 
 if (IOS)
-  set(MM_HDRS ${MM_HDRS} ios/iosinterface.h ios/iosviewdelegate.h)
+  set(MM_HDRS
+      ${MM_HDRS}
+      ios/iosinterface.h
+      ios/iosviewdelegate.h
+      position/tracking/iostrackingbackend.h
+      position/tracking/iostrackingbackendimpl.h
+  )
 
   set(MM_SRCS
       ${MM_SRCS}
@@ -229,6 +235,9 @@ if (IOS)
       ios/iosviewdelegate.mm
       ios/iosimagepicker.mm
       ios/iosutils.mm
+      position/tracking/iostrackingbackend.cpp
+      position/tracking/iostrackingbackend.mm
+      position/tracking/iostrackingbackendimpl.mm
   )
 endif ()
 
@@ -487,6 +496,11 @@ if (MACOS OR IOS)
                  AppleFrameworks::SystemConfiguration
   )
 endif ()
+
+if (IOS)
+    target_link_libraries(
+    Input PUBLIC AppleFrameworks::CoreLocation)
+endif()
 
 if (HAVE_APPLE_PURCHASING)
   target_link_libraries(

--- a/app/position/tracking/iostrackingbackend.cpp
+++ b/app/position/tracking/iostrackingbackend.cpp
@@ -1,0 +1,62 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "iostrackingbackend.h"
+#include "coreutils.h"
+
+IOSTrackingBackend::IOSTrackingBackend( UpdateFrequency frequency, QObject *parent )
+  : AbstractTrackingBackend( frequency, AbstractTrackingBackend::SignalSlotSupport::NotSupported, parent )
+  , mDistanceFilter( 1 )
+{
+  switch ( frequency )
+  {
+    case AbstractTrackingBackend::Often:
+      mDistanceFilter = 1;
+      break;
+
+    case AbstractTrackingBackend::Normal:
+      mDistanceFilter = 5;
+      break;
+
+    case AbstractTrackingBackend::Occasional:
+      mDistanceFilter = 20;
+      break;
+  }
+
+  startPositionProvider( this );
+}
+
+IOSTrackingBackend::~IOSTrackingBackend()
+{
+  releaseObjc();
+}
+
+void IOSTrackingBackend::positionUpdate( double longitude, double latitude, double altitude )
+{
+  GeoPosition position;
+  position.longitude = longitude;
+  position.latitude = latitude;
+  position.elevation = altitude;
+
+  notifyListeners( position );
+}
+
+void IOSTrackingBackend::logError( NSString *message )
+{
+  CoreUtils::log( TAG, QStringLiteral( "Error:" ) + QString::fromNSString( message ) );
+}
+
+void IOSTrackingBackend::stopTrying( NSString *message )
+{
+  CoreUtils::log( TAG, QStringLiteral( "Stopping updates, error:" ) + QString::fromNSString( message ) );
+
+  //
+  // let user know that tracking could not start/continue for some reason
+  //
+}

--- a/app/position/tracking/iostrackingbackend.h
+++ b/app/position/tracking/iostrackingbackend.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef IOSTRACKINGBACKEND_H
+#define IOSTRACKINGBACKEND_H
+
+#include "abstracttrackingbackend.h"
+
+#include <QObject>
+#include <qglobal.h>
+
+Q_FORWARD_DECLARE_OBJC_CLASS( IOSTrackingBackendImpl );
+
+class IOSTrackingBackend : public AbstractTrackingBackend
+{
+    Q_OBJECT
+
+  public:
+    explicit IOSTrackingBackend( AbstractTrackingBackend::UpdateFrequency frequency, QObject *parent = nullptr );
+    ~IOSTrackingBackend();
+
+    // methods called from obj-c
+    void positionUpdate( double longitude, double latitude, double altitude );
+    void stopTrying( NSString *message );
+    void logError( NSString *message );
+    // ---
+
+  private:
+    void startPositionProvider( IOSTrackingBackend *observer );
+    void releaseObjc();
+
+    QString TAG = QStringLiteral( "IOS Tracking backend" );
+
+    double mDistanceFilter = 0;
+    IOSTrackingBackendImpl *mBackendImpl = nullptr; // owned, in objective-c
+};
+
+#endif // IOSTRACKINGBACKEND_H

--- a/app/position/tracking/iostrackingbackend.mm
+++ b/app/position/tracking/iostrackingbackend.mm
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "iostrackingbackend.h"
+#include "iostrackingbackendimpl.h"
+
+#include "coreutils.h"
+
+void IOSTrackingBackend::startPositionProvider( IOSTrackingBackend *me )
+{
+  if ( mBackendImpl == nullptr )
+  {
+
+    @try
+    {
+      IOSTrackingBackendImpl *impl = [[IOSTrackingBackendImpl alloc] initWithObserver: this];
+      mBackendImpl = impl;
+    }
+    @catch ( NSException *e )
+    {
+      NSString *message = [NSString stringWithFormat:@"%@ %@", e.name, e.reason];
+
+      CoreUtils::log( TAG, QStringLiteral( "Fatal: unable to initialize location obj-c backend" ) + QString::fromNSString( message ) );
+    }
+  }
+
+  @try
+  {
+    [mBackendImpl setup: mDistanceFilter];
+  }
+  @catch ( NSException *e )
+  {
+    NSString *message = [ NSString stringWithFormat:@"%@ %@", e.name, e.reason ];
+
+    CoreUtils::log( TAG, QStringLiteral( "Fatal: unable to call setup" ) + QString::fromNSString( message ) );
+  }
+}
+
+void IOSTrackingBackend::releaseObjc()
+{
+  if ( mBackendImpl )
+  {
+    [mBackendImpl release];
+    mBackendImpl = nil;
+  }
+}

--- a/app/position/tracking/iostrackingbackendimpl.h
+++ b/app/position/tracking/iostrackingbackendimpl.h
@@ -1,0 +1,29 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef IOSTRACKINGBACKENDIMPL_H
+#define IOSTRACKINGBACKENDIMPL_H
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <CoreLocation/CoreLocation.h>
+
+#import "iostrackingbackend.h"
+
+@interface IOSTrackingBackendImpl : NSObject<CLLocationManagerDelegate>
+{
+  IOSTrackingBackend *mObserver;
+  CLLocationManager *mManager;
+}
+
+-( id )initWithObserver:( IOSTrackingBackend * )iosObserver;
+-( NSString * )setup:( double )distanceFilter;
+
+@end
+
+#endif // IOSTRACKINGBACKENDIMPL_H

--- a/app/position/tracking/iostrackingbackendimpl.mm
+++ b/app/position/tracking/iostrackingbackendimpl.mm
@@ -14,8 +14,6 @@
 
 - ( void )dealloc
 {
-  NSLog( @"Object deallocated" );
-
   if ( mManager )
   {
     [mManager stopUpdatingLocation];

--- a/app/position/tracking/iostrackingbackendimpl.mm
+++ b/app/position/tracking/iostrackingbackendimpl.mm
@@ -1,0 +1,94 @@
+
+#import "iostrackingbackendimpl.h"
+
+@implementation IOSTrackingBackendImpl
+
+-( id )initWithObserver:( IOSTrackingBackend * )iosObserver
+{
+  if ( ( self = [ super init ] ) )
+  {
+    mObserver = iosObserver;
+  }
+  return self;
+}
+
+- ( void )dealloc
+{
+  NSLog( @"Object deallocated" );
+
+  if ( mManager )
+  {
+    [mManager stopUpdatingLocation];
+    [mManager release];
+    mManager = nil;
+  }
+
+  if ( mObserver )
+  {
+    mObserver = nil;
+  }
+
+  [super dealloc];
+}
+
+-( NSString * ) setup:( double )distanceFilter
+{
+  NSString *response = @"";
+
+  if ( mManager == nil )
+  {
+    mManager = [[ CLLocationManager alloc ] init ];
+
+    response = [response stringByAppendingString:@"Info: Built location manager!"];
+  }
+
+  if ( [CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined )
+  {
+    [mManager requestWhenInUseAuthorization];
+
+    response = [response stringByAppendingString:@" Info: Requested authorization!"];
+  }
+  else
+  {
+    response = [response stringByAppendingString:@" Info: Did not request authorization, other state"];
+  }
+
+  response = [response stringByAppendingString:@" Requested location"];
+
+  mManager.distanceFilter = distanceFilter;
+  mManager.delegate = self;
+
+  [mManager startUpdatingLocation];
+  mManager.allowsBackgroundLocationUpdates = true;
+
+  response = [response stringByAppendingString:@" Started updates"];
+
+  return response;
+}
+
+- ( void )locationManager:( CLLocationManager * )manager didUpdateLocations:( NSArray * )locations
+{
+  CLLocation *location = [locations lastObject];
+
+  mObserver->positionUpdate( location.coordinate.longitude, location.coordinate.latitude, location.altitude );
+}
+
+- ( void )locationManager:( CLLocationManager * )manager didFailWithError:( NSError * )error
+{
+
+  NSString *message = [NSString stringWithFormat:@"%@ %@", @"Error:", error.localizedDescription];
+
+  if ( error.code == kCLErrorDenied )
+  {
+    // permission is not denied, do not try again
+    [mManager stopUpdatingLocation];
+    mObserver->stopTrying( message );
+  }
+  else
+  {
+    // some other error, but we can continue reading location
+    mObserver->logError( message );
+  }
+}
+
+@end

--- a/app/position/tracking/positiontrackingmanager.cpp
+++ b/app/position/tracking/positiontrackingmanager.cpp
@@ -10,7 +10,11 @@
 #include "positiontrackingmanager.h"
 
 #include "positionkit.h"
+
+// backend implementations
+#ifdef Q_OS_IOS
 #include "iostrackingbackend.h"
+#endif
 #include "internaltrackingbackend.h"
 
 #include "qgsproject.h"

--- a/cmake/FindAppleFrameworks.cmake
+++ b/cmake/FindAppleFrameworks.cmake
@@ -13,7 +13,9 @@ endif ()
 #
 # iOS AppleFrameworks::StoreKit AppleFrameworks::Foundation
 
-set(APPLE_FRAMEWORKS Security CoreFoundation SystemConfiguration)
+set(APPLE_FRAMEWORKS Security CoreFoundation SystemConfiguration CoreLocation)
+
+#find_library(CORE_LOCATION_FRAMEWORK CoreLocation)
 
 if (HAVE_APPLE_PURCHASING)
   set(APPLE_FRAMEWORKS ${APPLE_FRAMEWORKS} Foundation StoreKit)

--- a/cmake/FindAppleFrameworks.cmake
+++ b/cmake/FindAppleFrameworks.cmake
@@ -13,7 +13,12 @@ endif ()
 #
 # iOS AppleFrameworks::StoreKit AppleFrameworks::Foundation
 
-set(APPLE_FRAMEWORKS Security CoreFoundation SystemConfiguration CoreLocation)
+set(APPLE_FRAMEWORKS
+    Security
+    CoreFoundation
+    SystemConfiguration
+    CoreLocation
+)
 
 if (HAVE_APPLE_PURCHASING)
   set(APPLE_FRAMEWORKS ${APPLE_FRAMEWORKS} Foundation StoreKit)

--- a/cmake/FindAppleFrameworks.cmake
+++ b/cmake/FindAppleFrameworks.cmake
@@ -15,8 +15,6 @@ endif ()
 
 set(APPLE_FRAMEWORKS Security CoreFoundation SystemConfiguration CoreLocation)
 
-#find_library(CORE_LOCATION_FRAMEWORK CoreLocation)
-
 if (HAVE_APPLE_PURCHASING)
   set(APPLE_FRAMEWORKS ${APPLE_FRAMEWORKS} Foundation StoreKit)
 endif ()

--- a/cmake_templates/iOSInfo.plist.in
+++ b/cmake_templates/iOSInfo.plist.in
@@ -92,6 +92,11 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<!-- Run the app when minimised while tracking position -->
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Adds native `CLLocationManager`(https://developer.apple.com/documentation/corelocation/cllocationmanager?language=objc) implementation of position tracking backend. Used only on iOS devices (iPhones, iPads)

- supports background use
- notifies PositionTrackingManager about change in position. 
- uses `CLLocationManager distanceFilter` ( see https://developer.apple.com/documentation/corelocation/cllocationmanager/1423500-distancefilter?language=objc ) to update frequency of position updates
- does not use signal/slot connections as these are not delivered when app is minimised on iOS