### PR TITLE
use Lutra's vector tile layer for background map 

### DIFF
--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -12,7 +12,7 @@
 #include "coreutils.h"
 
 #include "qgsproject.h"
-#include "qgsrasterlayer.h"
+#include "qgsvectortilelayer.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsdatetimefieldformatter.h"
@@ -102,8 +102,18 @@ void ProjectWizard::createProject( QString const &projectName, FieldsModel *fiel
   QgsProject project;
 
   // add layers
-  QString urlWithParams( BG_MAPS_CONFIG );
-  QgsRasterLayer *bgLayer = new QgsRasterLayer( BG_MAPS_CONFIG, QStringLiteral( "OpenStreetMap" ), QStringLiteral( "wms" ) );
+  QgsDataSourceUri dsUri;
+  dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  dsUri.setParam( QStringLiteral( "url" ), QStringLiteral( "https://vtiles.dev.merginmaps.com/data/v3/{z}/{x}/{y}.pbf" ) );
+  dsUri.setParam( QStringLiteral( "styleUrl" ), QStringLiteral( "https://vtiles.dev.merginmaps.com/styles/basic-preview-global/style.json" ) );
+  dsUri.setParam( QStringLiteral( "zmin" ), QStringLiteral( "0" ) );
+  dsUri.setParam( QStringLiteral( "zmax" ), QStringLiteral( "14" ) );
+  QgsVectorTileLayer *bgLayer = new QgsVectorTileLayer( dsUri.encodedUri(), QStringLiteral( "OpenMapTiles(OSM)" ) );
+  bool ok;
+  QString error = bgLayer->loadDefaultStyle( ok );
+  QgsLayerMetadata metadata;
+  metadata.setRights( QStringList() << QStringLiteral( "© OpenMapTiles © OpenStreetMap contributors" ) );
+  bgLayer->setMetadata( metadata );
   QgsVectorLayer *layer = createGpkgLayer( projectDir, fieldsModel->fields() );
   QList<QgsMapLayer *> layers;
   layers << layer << bgLayer;

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -106,11 +106,11 @@ void ProjectWizard::createProject( QString const &projectName, FieldsModel *fiel
   // add layers
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
-  dsUri.setParam( QStringLiteral( "url" ), QStringLiteral( "%1/data/v3/{z}/{x}/{y}.pbf" ).arg( TILES_URL ) );
-  dsUri.setParam( QStringLiteral( "styleUrl" ), QStringLiteral( "%1/styles/basic-preview-global/style.json" ).arg( TILES_URL ) );
+  dsUri.setParam( QStringLiteral( "url" ), QStringLiteral( "%1/data/default/{z}/{x}/{y}.pbf" ).arg( TILES_URL ) );
+  dsUri.setParam( QStringLiteral( "styleUrl" ), QStringLiteral( "%1/styles/default.json" ).arg( TILES_URL ) );
   dsUri.setParam( QStringLiteral( "zmin" ), QStringLiteral( "0" ) );
   dsUri.setParam( QStringLiteral( "zmax" ), QStringLiteral( "14" ) );
-  QgsVectorTileLayer *bgLayer = new QgsVectorTileLayer( dsUri.encodedUri(), QStringLiteral( "OpenMapTiles(OSM)" ) );
+  QgsVectorTileLayer *bgLayer = new QgsVectorTileLayer( dsUri.encodedUri(), QStringLiteral( "OpenMapTiles (OSM)" ) );
   bool ok;
   QString error = bgLayer->loadDefaultStyle( ok );
   QgsLayerMetadata metadata;

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -25,6 +25,8 @@
 #include "inpututils.h"
 #include "coreutils.h"
 
+const QString TILES_URL = QStringLiteral( "https://vtiles.merginmaps.com" );
+
 ProjectWizard::ProjectWizard( const QString &dataDir, QObject *parent )
   : QObject( parent )
   , mDataDir( dataDir )
@@ -104,8 +106,8 @@ void ProjectWizard::createProject( QString const &projectName, FieldsModel *fiel
   // add layers
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
-  dsUri.setParam( QStringLiteral( "url" ), QStringLiteral( "https://vtiles.dev.merginmaps.com/data/v3/{z}/{x}/{y}.pbf" ) );
-  dsUri.setParam( QStringLiteral( "styleUrl" ), QStringLiteral( "https://vtiles.dev.merginmaps.com/styles/basic-preview-global/style.json" ) );
+  dsUri.setParam( QStringLiteral( "url" ), QStringLiteral( "%1/data/v3/{z}/{x}/{y}.pbf" ).arg( TILES_URL ) );
+  dsUri.setParam( QStringLiteral( "styleUrl" ), QStringLiteral( "%1/styles/basic-preview-global/style.json" ).arg( TILES_URL ) );
   dsUri.setParam( QStringLiteral( "zmin" ), QStringLiteral( "0" ) );
   dsUri.setParam( QStringLiteral( "zmax" ), QStringLiteral( "14" ) );
   QgsVectorTileLayer *bgLayer = new QgsVectorTileLayer( dsUri.encodedUri(), QStringLiteral( "OpenMapTiles(OSM)" ) );

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -25,7 +25,7 @@
 #include "inpututils.h"
 #include "coreutils.h"
 
-const QString TILES_URL = QStringLiteral( "https://vtiles.merginmaps.com" );
+const QString TILES_URL = QStringLiteral( "https://tiles.merginmaps.com" );
 
 ProjectWizard::ProjectWizard( const QString &dataDir, QObject *parent )
   : QObject( parent )

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -58,7 +58,6 @@ class ProjectWizard : public QObject
     QString mDataDir;
     std::unique_ptr<QgsMapSettings> mSettings = nullptr;
 
-    const QString BG_MAPS_CONFIG = QStringLiteral( "tilePixelRatio=1&type=xyz&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0" );
     const QString PROJECT_CRS_ID = QStringLiteral( "EPSG:3857" );
     const QString LAYER_CRS_ID = QStringLiteral( "EPSG:4326" );
 };


### PR DESCRIPTION
When creating a new project use Lutra's vector tiles instead of OSM XYZ layer. Vector tile layer loaded with the predefined style coming from the Lutra server.