### PR TITLE
remove Locale workaround

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -513,52 +513,6 @@ void InputUtils::quitApp()
   }
 }
 
-QLocale InputUtils::fixLocaleCountry( QLocale applocale )
-{
-  QLocale out = applocale;
-
-  if ( applocale.language() == QLocale::English )
-  {
-    out = QLocale( QLocale::English, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::German || applocale.language() == QLocale::LowGerman || applocale.language() == QLocale::SwissGerman )
-  {
-    out = QLocale( QLocale::German, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::French )
-  {
-    out = QLocale( QLocale::French, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::Italian )
-  {
-    out = QLocale( QLocale::Italian, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::Spanish )
-  {
-    out = QLocale( QLocale::Spanish, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::Turkish )
-  {
-    out = QLocale( QLocale::Turkish, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::Polish )
-  {
-    out = QLocale( QLocale::Polish, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::Slovak )
-  {
-    out = QLocale( QLocale::Slovak, QLocale::AnyCountry );
-  }
-  else if ( applocale.language() == QLocale::Croatian )
-  {
-    out = QLocale( QLocale::Croatian, QLocale::AnyCountry );
-  }
-
-  CoreUtils::log( QStringLiteral( "Locale" ), QStringLiteral( "Converting %1 locale to simple %2" ).arg( applocale.name(), out.name() ) );
-
-  return out;
-}
-
 QString InputUtils::appPlatform()
 {
 #if defined( ANDROID )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -138,9 +138,6 @@ class InputUtils: public QObject
 
     Q_INVOKABLE void quitApp();
 
-    // Removes country code from locale and replaces it with AnyCountry
-    static QLocale fixLocaleCountry( QLocale applocale );
-
     /**
      * Method copies all entries from given source path to destination path. If cannot copy a file for the first time,
      * removes it and tries again (overwrite a file). If failes again, skips the file, sets result to false and continue.

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -418,21 +418,6 @@ int main( int argc, char *argv[] )
   // Initialize translations
   QLocale locale;
 
-  /*
-   * We need to fix locale country code (capital letters after underscore)
-   * in system locale, because QT tries to do exact match, for example:
-   * system locale "en_GB" -> our provided locale "en" would not match and
-   * QT would try to find translation for other system language.
-   *
-   * If it fails it goes through the same process again, but without country code.
-   * We want to match "en_GB" with "en" immediately, thus we remove the country code.
-   *
-   * This fix can be removed from QT 5.15
-   * See: https://github.com/MerginMaps/input/issues/1417
-   * See: QTBUG-86179
-   */
-  locale = InputUtils::fixLocaleCountry( locale );
-
   QTranslator inputTranslator;
   if ( inputTranslator.load( locale, "input", "_", ":/" ) )
   {

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -703,34 +703,6 @@ void TestUtilsFunctions::testGeometryIcons()
   }
 }
 
-void TestUtilsFunctions::testFixCountryCode()
-{
-  QVector< QPair< QLocale, QLocale > > testcases =
-  {
-    { QLocale( QLocale::English, QLocale::Canada ), QLocale( QLocale::English, QLocale::AnyCountry ) },
-    { QLocale( QLocale::English, QLocale::UnitedStates ), QLocale( QLocale::English, QLocale::AnyCountry ) },
-    { QLocale( QLocale::English, QLocale::UnitedKingdom ), QLocale( QLocale::English, QLocale::AnyCountry ) },
-    { QLocale( QLocale::English, QLocale::Australia ), QLocale( QLocale::English, QLocale::AnyCountry ) },
-    { QLocale( QLocale::English, QLocale::NewZealand ), QLocale( QLocale::English, QLocale::AnyCountry ) },
-
-    { QLocale( QLocale::French, QLocale::Canada ), QLocale( QLocale::French, QLocale::AnyCountry ) },
-    { QLocale( QLocale::French, QLocale::France ), QLocale( QLocale::French, QLocale::AnyCountry ) },
-    { QLocale( QLocale::French, QLocale::Belgium ), QLocale( QLocale::French, QLocale::AnyCountry ) },
-
-    { QLocale( QLocale::Spanish, QLocale::Spain ), QLocale( QLocale::Spanish, QLocale::AnyCountry ) },
-    { QLocale( QLocale::Spanish, QLocale::Mexico ), QLocale( QLocale::Spanish, QLocale::AnyCountry ) },
-
-    { QLocale( QLocale::Slovak, QLocale::Slovakia ), QLocale( QLocale::Slovak, QLocale::AnyCountry ) },
-
-    { QLocale( QLocale::Polish, QLocale::Poland ), QLocale( QLocale::Polish, QLocale::AnyCountry ) }
-  };
-
-  for ( const auto &test : testcases )
-  {
-    QCOMPARE( mUtils->fixLocaleCountry( test.first ), test.second );
-  }
-}
-
 void TestUtilsFunctions::testCreateGeometryForLayer()
 {
   QVector< QPair< QString, QgsWkbTypes::Type > > testcases =

--- a/app/test/testutilsfunctions.h
+++ b/app/test/testutilsfunctions.h
@@ -43,7 +43,6 @@ class TestUtilsFunctions: public QObject
     void testMapPointToGps();
     void testEquals();
     void testGeometryIcons();
-    void testFixCountryCode();
     void testCreateGeometryForLayer();
     void testInvalidGeometryWarning();
 


### PR DESCRIPTION
Qt 6.x already tries Locale without country in QTranslator::load() function

fix https://github.com/MerginMaps/input/issues/1417

see Qt6 logic in https://doc.qt.io/qt-6/qtranslator.html#load which is good.

tested on Android with EN (us) + FR (Canada) languages.