### PR TITLE
qmlfmt (formatting QML)

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -113,5 +113,4 @@ jobs:
           export PATH=${{ github.workspace }}/build-qmlfmt:$PATH
           which qmlfmt
           qmlfmt -v
-
           ./input/scripts/format_qml.bash

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -6,7 +6,13 @@ on:
     - 'app/**'
     - 'core/**'
     - 'gallery/**'
-
+    - 'scripts/**'
+    - 'test/**'
+    - 'cmake/**'
+    - 'cmake_templates/**'
+    - 'CMakeLists.txt'
+    - '.github/workflows/code_style.yml'
+    
   release:
     types:
       - published

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -69,10 +69,9 @@ jobs:
         with:
           path: input
 
-      - name: Cache qmlfmt
-        uses: actions/cache/save@v3
-        if: always()
-        id: cache-qmlfmt
+      - name: Restore cached Primes
+        id: cache-qmlfmt-restore
+        uses: actions/cache/restore@v3
         with:
           path: ${{ github.workspace }}/build-qmlfmt
           key: cache-v${{ env.CACHE_VERSION }}-qt-${{ env.QT_VERSION }}-qmlfmt
@@ -88,7 +87,7 @@ jobs:
           cache-key-prefix: ${{ runner.os }}-QtCache-v0-${{ env.QT_VERSION }}-codestyle
           
       - name: Install qmlfmt
-        if: steps.cache-qmlfmt.outputs.cache-hit != 'true'
+        if: steps.cache-qmlfmt-restore.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/jesperhh/qmlfmt.git
           cd ${{ github.workspace }}/qmlfmt
@@ -101,9 +100,17 @@ jobs:
           cmake ../qmlfmt -DBUILD_TESTING=OFF
           make
 
+      - name: Cache qmlfmt
+        uses: actions/cache/save@v3
+        if: always()
+        id: cache-qmlfmt-save
+        with:
+          path: ${{ github.workspace }}/build-qmlfmt
+          key: cache-v${{ env.CACHE_VERSION }}-qt-${{ env.QT_VERSION }}-qmlfmt
+
       - name: Run style check
         run: |
-          export PATH=${{ github.workspace }}/build-qmlfmt/bin:$PATH
+          export PATH=${{ github.workspace }}/build-qmlfmt:$PATH
           which qmlfmt
           qmlfmt -v
 

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -70,7 +70,7 @@ jobs:
           path: input
 
       - name: Cache qmlfmt
-        uses: actions/cache@v3
+        uses: pat-s/always-upload-cache@v3.0.11
         id: cache-qmlfmt
         with:
           path: ${{ github.workspace }}/install-qmlfmt
@@ -101,15 +101,16 @@ jobs:
           cmake ../qmlfmt -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-qmlfmt
           make
           make install
-          cd ${{ github.workspace }}/install-qmlfmt 
+          cd ${{ github.workspace }}/install-qmlfmt
+          ls ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/
+          otool -l ${{ github.workspace }}/install-qmlfmt/bin/qmlfmt
           install_name_tool -add_rpath ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/ qmlfmt
 
       - name: Run style check
         run: |
-          ls ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/
           otool -l ${{ github.workspace }}/install-qmlfmt/bin/qmlfmt
           
           export PATH=${{ github.workspace }}/install-qmlfmt/bin:$PATH
-          
+          which qmlfmt
           qmlfmt -v
           ./input/scripts/format_qml.bash

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -5,11 +5,16 @@ on:
     paths:
     - 'app/**'
     - 'core/**'
+    - 'gallery/**'
 
   release:
     types:
       - published
 
+env:
+  QT_VERSION: '6.5.2'
+  CACHE_VERSION: 0
+  
 jobs:
   code_style_cpp:
     name: C++ code convention check
@@ -49,8 +54,7 @@ jobs:
           
   code_style_qml:
     name: QML code convention check
-    if: ${{ false }}  # disable for now
-    # if: ( github.repository == 'MerginMaps/input' ) && (!contains(github.event.head_commit.message, 'Translate '))
+    if: ( github.repository == 'MerginMaps/input' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: macos-latest
     steps:
 
@@ -59,8 +63,42 @@ jobs:
         with:
           path: input
 
-      - name: Install deps
-        run: brew install martindelille/tap/qmlfmt
+      - name: Cache qmlfmt
+        uses: actions/cache@v3
+        id: cache-qmlfmt
+        with:
+          path: ${{ github.workspace }}/install-qmlfmt
+          key: cache-v${{ env.CACHE_VERSION }}-${{ env.QT_VERSION }}
+
+      # Qt
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: ${{ env.QT_VERSION }}
+          target: desktop
+          dir: ${{ github.workspace }}
+          modules: 'qtsensors qtconnectivity qt5compat qtmultimedia qtpositioning qtshadertools'
+          cache: true
+          cache-key-prefix: ${{ runner.os }}-QtCache-v0-${{ env.QT_VERSION }}-codestyle
+          
+      - name: Install qmlfmt
+        if: steps.cache-qmlfmt.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/jesperhh/qmlfmt.git
+          cd ${{ github.workspace }}/qmlfmt
+          git submodule update --init qt-creator
+          mkdir ${{ github.workspace }}/install-qmlfmt
+          cd ${{ github.workspace }}/install-qmlfmt
+          export Qt6_DIR="${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/cmake/Qt6"
+          export Qt6GuiTools_DIR="${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/cmake/Qt6GuiTools"
+          export Qt6Test_DIR="${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/cmake/Qt6Test"
+          cmake ../qmlfmt -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-qmlfmt
+          make
+          make install
 
       - name: Run style check
-        run: ./input/scripts/format_qml.bash
+        run: |
+          export PATH=${{ github.workspace }}/install-qmlfmt/bin:$PATH
+          export DYLD_FRAMEWORK_PATH=${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib
+          qmlfmt -v
+          ./input/scripts/format_qml.bash

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   QT_VERSION: '6.5.2'
-  CACHE_VERSION: 1
+  CACHE_VERSION: 0
   
 jobs:
   code_style_cpp:
@@ -70,13 +70,13 @@ jobs:
           path: input
 
       - name: Cache qmlfmt
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: actions/cache/save@v3
+        if: always()
         id: cache-qmlfmt
         with:
-          path: ${{ github.workspace }}/install-qmlfmt
-          key: cache-v${{ env.CACHE_VERSION }}-${{ env.QT_VERSION }}
+          path: ${{ github.workspace }}/build-qmlfmt
+          key: cache-v${{ env.CACHE_VERSION }}-qt-${{ env.QT_VERSION }}-qmlfmt
 
-      # Qt
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
@@ -93,24 +93,18 @@ jobs:
           git clone https://github.com/jesperhh/qmlfmt.git
           cd ${{ github.workspace }}/qmlfmt
           git submodule update --init qt-creator
-          mkdir ${{ github.workspace }}/install-qmlfmt
-          cd ${{ github.workspace }}/install-qmlfmt
+          mkdir ${{ github.workspace }}/build-qmlfmt
+          cd ${{ github.workspace }}/build-qmlfmt
           export Qt6_DIR="${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/cmake/Qt6"
           export Qt6GuiTools_DIR="${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/cmake/Qt6GuiTools"
           export Qt6Test_DIR="${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/cmake/Qt6Test"
-          cmake ../qmlfmt -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-qmlfmt
+          cmake ../qmlfmt -DBUILD_TESTING=OFF
           make
-          make install
-          cd ${{ github.workspace }}/install-qmlfmt
-          ls ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/
-          otool -l ${{ github.workspace }}/install-qmlfmt/bin/qmlfmt
-          install_name_tool -add_rpath ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/ qmlfmt
 
       - name: Run style check
         run: |
-          otool -l ${{ github.workspace }}/install-qmlfmt/bin/qmlfmt
-          
-          export PATH=${{ github.workspace }}/install-qmlfmt/bin:$PATH
+          export PATH=${{ github.workspace }}/build-qmlfmt/bin:$PATH
           which qmlfmt
           qmlfmt -v
+
           ./input/scripts/format_qml.bash

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   QT_VERSION: '6.5.2'
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
   
 jobs:
   code_style_cpp:
@@ -101,10 +101,11 @@ jobs:
           cmake ../qmlfmt -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-qmlfmt
           make
           make install
+          cd ${{ github.workspace }}/install-qmlfmt 
+          install_name_tool -add_rpath ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/ qmlfmt
 
       - name: Run style check
         run: |
           export PATH=${{ github.workspace }}/install-qmlfmt/bin:$PATH
-          export DYLD_FRAMEWORK_PATH=${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib
           qmlfmt -v
           ./input/scripts/format_qml.bash

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -106,6 +106,10 @@ jobs:
 
       - name: Run style check
         run: |
+          ls ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos/lib/
+          otool -l ${{ github.workspace }}/install-qmlfmt/bin/qmlfmt
+          
           export PATH=${{ github.workspace }}/install-qmlfmt/bin:$PATH
+          
           qmlfmt -v
           ./input/scripts/format_qml.bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,7 +93,9 @@ openssl aes-256-cbc -d -in merginsecrets.cpp.enc -out merginsecrets.cpp -md md5
 
 ## 2.2 Code formatting
 
-We are using `astyle` to format CPP and Objective-C files. Format is similar to what QGIS have.
+We use `astyle` to format CPP and Objective-C files. Format is similar to what QGIS has.
+
+For QML files we use latest version of `jesperhh/qmlfmt`. To install, follow instruction on the GitHub of the project. 
 
 We also use software [pre-commit](https://pre-commit.com/) to automatically check format when doing a commit.
 You need to install it via `brew`/`pip`, see [installation details](https://pre-commit.com/#installation).

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Read more about the app [https://merginmaps.com/docs](https://merginmaps.com/doc
 
 To setup your development environment, read [INSTALL](./INSTALL.md)
 
-New sub-project 'gallery' app is used to develop/design (later to see) all UI components, used in the Mergin Maps app
+New sub-project 'gallery' app is used to develop/design all UI components, used in the Mergin Maps app
 
 ## Privacy policy
 Read more about the app privacy policy [here](https://merginmaps.com/docs/reference/privacy/)

--- a/gallery/CMakeLists.txt
+++ b/gallery/CMakeLists.txt
@@ -1,56 +1,68 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(gallery VERSION 0.1 LANGUAGES CXX)
+project(
+  gallery
+  VERSION 0.1
+  LANGUAGES CXX
+)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(QT6_VERSION ${QT_VERSION_DEFAULT} CACHE STRING "QT6 version to use")
+set(QT6_VERSION
+    ${QT_VERSION_DEFAULT}
+    CACHE STRING "QT6 version to use"
+)
 set(CMAKE_AUTORCC ON)
 
 find_package(
-    Qt6 ${QT6_VERSION}
-    COMPONENTS Quick
-               Qml
-               Concurrent
-               Positioning
-               QuickControls2
-               Svg
-               Core
-               Core5Compat
-    REQUIRED
+  Qt6 ${QT6_VERSION}
+  COMPONENTS Quick
+             Qml
+             Concurrent
+             Positioning
+             QuickControls2
+             Svg
+             Core
+             Core5Compat
+  REQUIRED
 )
 
 qt_standard_project_setup(REQUIRES 6.5)
 
-qt_add_executable(appGallery
-    main.cpp qml.qrc fonts.qrc
-    hotreload.cpp hotreload.h
-    helper.cpp helper.h
-)
-
-qt_add_qml_module(appGallery
-    URI gallery
-    VERSION 1.0
-    QML_FILES qml/Main.qml
-)
-
-set_target_properties(appGallery PROPERTIES
-    MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
-    MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-    MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-    MACOSX_BUNDLE TRUE
-    WIN32_EXECUTABLE TRUE
-)
-
-target_link_libraries(appGallery
-    PRIVATE Qt6::Quick
-)
-
-install(TARGETS appGallery
-    BUNDLE DESTINATION .
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
-qt_add_resources(
+qt_add_executable(
+  appGallery
+  main.cpp
+  qml.qrc
   fonts.qrc
+  hotreload.cpp
+  hotreload.h
+  helper.cpp
+  helper.h
 )
+
+qt_add_qml_module(
+  appGallery
+  URI gallery
+  VERSION 1.0
+  QML_FILES qml/Main.qml
+)
+
+set_target_properties(
+  appGallery
+  PROPERTIES MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
+             MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+             MACOSX_BUNDLE_SHORT_VERSION_STRING
+             ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+             MACOSX_BUNDLE TRUE
+             WIN32_EXECUTABLE TRUE
+)
+
+target_link_libraries(appGallery PRIVATE Qt6::Quick)
+
+install(
+  TARGETS appGallery
+  BUNDLE DESTINATION .
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+qt_add_resources(fonts.qrc)

--- a/gallery/helper.cpp
+++ b/gallery/helper.cpp
@@ -12,7 +12,7 @@
 #include <QScreen>
 #include <QFontDatabase>
 
-Helper::Helper(QObject *parent) : QObject{parent}
+Helper::Helper( QObject *parent ) : QObject{parent}
 {
 
 }
@@ -24,9 +24,10 @@ QString Helper::installFonts()
         << ":/fonts/Inter-SemiBold.ttf";
   for ( const QString &font : fonts )
   {
-    if ( QFontDatabase::addApplicationFont( font ) == -1 ) {
+    if ( QFontDatabase::addApplicationFont( font ) == -1 )
+    {
       qDebug() << "!! Failed to load font" << font;
-      exit(3);
+      exit( 3 );
     }
     else
       qDebug() << "Loaded font" << font;

--- a/gallery/helper.h
+++ b/gallery/helper.h
@@ -14,18 +14,18 @@
 
 class Helper : public QObject
 {
-  Q_OBJECT
-public:
-  explicit Helper(QObject *parent = nullptr);
+    Q_OBJECT
+  public:
+    explicit Helper( QObject *parent = nullptr );
 
-  // Install custom fonts
-  static QString installFonts();
+    // Install custom fonts
+    static QString installFonts();
 
-  // Calculates real screen DPR based on DPI
-  static qreal calculateScreenDpr();
+    // Calculates real screen DPR based on DPI
+    static qreal calculateScreenDpr();
 
-  // Calculates ratio between real DPR calculated by us with DPR calculated by QT that is later used in qml sizing
-  static qreal calculateDpRatio();
+    // Calculates ratio between real DPR calculated by us with DPR calculated by QT that is later used in qml sizing
+    static qreal calculateDpRatio();
 };
 
 #endif // HELPER_H

--- a/gallery/hotreload.cpp
+++ b/gallery/hotreload.cpp
@@ -26,36 +26,38 @@ while true; do \n\
 done";
 }
 
-HotReload::HotReload(QQmlApplicationEngine& engine, QObject *parent):
-  _engine(engine)
+HotReload::HotReload( QQmlApplicationEngine &engine, QObject *parent ):
+  _engine( engine )
 {
   // create dirs for sync (near the app)
-  if(!QDir("HotReload/gallery/qml/").exists())
-    QDir().mkpath(QGuiApplication::applicationDirPath() + "/HotReload/gallery/qml/");
-  if(!QDir("HotReload/app/qmlV2/").exists())
-    QDir().mkpath(QGuiApplication::applicationDirPath() + "/HotReload/app/qmlV2/");
+  if ( !QDir( "HotReload/gallery/qml/" ).exists() )
+    QDir().mkpath( QGuiApplication::applicationDirPath() + "/HotReload/gallery/qml/" );
+  if ( !QDir( "HotReload/app/qmlV2/" ).exists() )
+    QDir().mkpath( QGuiApplication::applicationDirPath() + "/HotReload/app/qmlV2/" );
 
   // create runnable sync script (near the app)
   QString scriptFilename = QGuiApplication::applicationDirPath() + "/syncGallery.sh";
   qInfo() << "Sync script location: " << scriptFilename;
-  if(!QFileInfo::exists(scriptFilename)) {
-    QFile file(QFileInfo(scriptFilename).absoluteFilePath());
+  if ( !QFileInfo::exists( scriptFilename ) )
+  {
+    QFile file( QFileInfo( scriptFilename ).absoluteFilePath() );
     const QString script = syncScript();
-    if (!file.open(QIODevice::WriteOnly)) {
+    if ( !file.open( QIODevice::WriteOnly ) )
+    {
       qInfo() << "Cannot create script file";
-      exit(1);
+      exit( 1 );
     }
-    QTextStream out(&file);
+    QTextStream out( &file );
     out << script;
     file.close();
-    QProcess::execute("chmod", QStringList() << "+x" << file.fileName());
+    QProcess::execute( "chmod", QStringList() << "+x" << file.fileName() );
   }
 
   // run sync script
-  QProcess::startDetached("./syncGallery.sh");
+  QProcess::startDetached( "./syncGallery.sh" );
 
   // start watching the changes in synced dirs
-  QTimer::singleShot(2000, this, &HotReload::startHotReload);
+  QTimer::singleShot( 2000, this, &HotReload::startHotReload );
 }
 
 void HotReload::clearCache()
@@ -65,13 +67,14 @@ void HotReload::clearCache()
 
 void HotReload::startHotReload()
 {
-  _watcher = new QFileSystemWatcher(this);
-  _watcher->addPath("HotReload/gallery/qml/Pages");
-  _watcher->addPath("HotReload/app/qmlV2");
-  _watcher->addPath("HotReload/app/qmlV2/component");
+  _watcher = new QFileSystemWatcher( this );
+  _watcher->addPath( "HotReload/gallery/qml/Pages" );
+  _watcher->addPath( "HotReload/app/qmlV2" );
+  _watcher->addPath( "HotReload/app/qmlV2/component" );
 
   // send signal for hot reloading
-  connect(_watcher, &QFileSystemWatcher::directoryChanged, this, [this](const QString& path){
+  connect( _watcher, &QFileSystemWatcher::directoryChanged, this, [this]( const QString & path )
+  {
     emit watchedSourceChanged();
-  });
+  } );
 }

--- a/gallery/hotreload.h
+++ b/gallery/hotreload.h
@@ -17,23 +17,23 @@ class QFileSystemWatcher;
 
 class HotReload : public QObject
 {
-  Q_OBJECT
-public:
-  explicit HotReload(QQmlApplicationEngine& engine, QObject *parent = nullptr);
+    Q_OBJECT
+  public:
+    explicit HotReload( QQmlApplicationEngine &engine, QObject *parent = nullptr );
 
-signals:
-  void watchedSourceChanged();
+  signals:
+    void watchedSourceChanged();
 
-public slots:
-  void clearCache();
-  void startHotReload();
+  public slots:
+    void clearCache();
+    void startHotReload();
 
-private:
-  QString syncScript() const;
+  private:
+    QString syncScript() const;
 
-private:
-  QFileSystemWatcher *_watcher;
-  QQmlApplicationEngine& _engine;
+  private:
+    QFileSystemWatcher *_watcher;
+    QQmlApplicationEngine &_engine;
 };
 
 #endif // HOTRELOAD_H

--- a/gallery/main.cpp
+++ b/gallery/main.cpp
@@ -15,22 +15,22 @@
 #include <QFont>
 #include <QFontDatabase>
 
-int main(int argc, char *argv[])
+int main( int argc, char *argv[] )
 {
-  QGuiApplication app(argc, argv);
+  QGuiApplication app( argc, argv );
 
   app.setFont( QFont( Helper::installFonts() ) );
 
   QQmlApplicationEngine engine;
-  HotReload hotReload(engine);
-  engine.rootContext()->setContextProperty("_hotReload", &hotReload);
+  HotReload hotReload( engine );
+  engine.rootContext()->setContextProperty( "_hotReload", &hotReload );
   // path to local wrapper pages
-  engine.rootContext()->setContextProperty("_qmlWrapperPath", QGuiApplication::applicationDirPath() + "/HotReload/gallery/qml/pages/");
+  engine.rootContext()->setContextProperty( "_qmlWrapperPath", QGuiApplication::applicationDirPath() + "/HotReload/gallery/qml/pages/" );
   engine.rootContext()->setContextProperty( "__dp", Helper::calculateDpRatio() );
 
-  QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
-    &app, []() { QCoreApplication::exit(-1); }, Qt::QueuedConnection);
-  engine.loadFromModule("gallery", "Main");
+  QObject::connect( &engine, &QQmlApplicationEngine::objectCreationFailed,
+  &app, []() { QCoreApplication::exit( -1 ); }, Qt::QueuedConnection );
+  engine.loadFromModule( "gallery", "Main" );
 
   return app.exec();
 }

--- a/scripts/format_all.bash
+++ b/scripts/format_all.bash
@@ -2,14 +2,12 @@
 
 # Script formats both cpp and qml files - intended to be used locally.
 
-set -e
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PWD=`pwd`
 cd $DIR
 
+./format_cmake.bash
 ./format_cpp.bash
-
 ./format_qml.bash
 
 cd $PWD

--- a/scripts/format_cpp.bash
+++ b/scripts/format_cpp.bash
@@ -5,5 +5,5 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PWD=`pwd`
 cd $DIR
-./astyle.bash `find ../core ../app -name \*.mm* -print -o -name \*.h* -print -o -name \*.c* -print`
+./astyle.bash `find ../core ../app ../gallery -name \*.mm* -print -o -name \*.h* -print -o -name \*.c* -print`
 cd $PWD

--- a/scripts/format_qml.bash
+++ b/scripts/format_qml.bash
@@ -12,39 +12,7 @@ cd $DIR
 # of their functionality (and bugs) we moved to qmlfmt.
 # See https://bugreports.qt.io/browse/QTBUG-98422 - if this bug is fixed and
 # released, we can move back to Qt's qmlformat.
-
-# Code that is commented out is a leftover from using qmlformat, it is kept
-# to be used in future
-
-# <QMLFORMAT CODE>
-# FORMATTER=""
-#
-# if [ $# -eq 0 ]; then
-#     # No arguments provided, need to look for qmlformat in path
-#     which qmlformat
-#
-#     if [ $? -ne 0 ]; then
-#     	echo "[!] qmlformat not found in PATH" >&2
-#     	exit 1
-#     fi
-#
-#     FORMATTER=`which qmlformat`
-# else
-#     FORMATTER=`which $1`
-#
-#     if [ $? -ne 0 ]; then
-#       echo "[!] passed qmlformat is invalid" >&2
-#       exit 1
-#     fi
-# fi
-#
-# ${FORMATTER} -v | grep -q "6."
-#
-# if [ $? -ne 0 ]; then
-#   echo "[!] qmlformat needs to be from Qt version 6.2 or higher! "
-#   exit 1
-# fi
-# </QMLFORMAT CODE>
+# Critially, qmlformat removes (empty) whitelines from function bodies 
 
 FORMATTER=`which qmlfmt`
 
@@ -57,7 +25,7 @@ echo "Starting to format QML files"
 
 RETURN=0
 
-FILES=`find ../app -name \*.qml* -print`
+FILES=`find ../app ../gallery -name \*.qml* -print`
 
 # <QMLFORMAT CODE>
 # --indent-width 2: use 2 spaces to indent


### PR DESCRIPTION
fix https://github.com/MerginMaps/input/issues/1799

add CI check for formatting QML; QT's qmlformat removes empty lines from function bodies, so stick with qmlfmt tool for now. 

The `./scripts/format_qml` is not run intentionally , so the mergin between dev-2.3 and master is without conflicts for now.
