### PR TITLE
Use automatic signing on iOS for local development

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -186,6 +186,7 @@ jobs:
           cmake \
             -DCMAKE_TOOLCHAIN_FILE:PATH="${{ github.workspace }}/ios-cmake/ios.toolchain.cmake" \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios \
+            -DIOS_USE_PRODUCTION_SIGNING=TRUE \
             -DQT_HOST_PATH=${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/macos \
             -DIOS=TRUE \
             -DCMAKE_INSTALL_PREFIX:PATH=../install-Input \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,9 +128,9 @@ set(QGIS_QUICK_DATA_PATH
 )
 set(IOS_USE_PRODUCTION_SIGNING
     FALSE
-    CACHE 
-    BOOL 
-    "Whether to sign the ios build with production certificate. Used in CI, leave false when building locally to automatically manage signing"
+    CACHE
+      BOOL
+      "Whether to sign the ios build with production certificate. Used in CI, leave false when building locally to automatically manage signing"
 )
 set(INPUT_SDK_PATH
     ${INPUT_SDK_PATH_DEFAULT}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,12 @@ set(QGIS_QUICK_DATA_PATH
     "INPUT"
     CACHE STRING "The internal variable pointing to the application storage folder"
 )
+set(IOS_USE_PRODUCTION_SIGNING
+    FALSE
+    CACHE 
+    BOOL 
+    "Whether to sign the ios build with production certificate. Used in CI, leave false when building locally to automatically manage signing"
+)
 set(INPUT_SDK_PATH
     ${INPUT_SDK_PATH_DEFAULT}
     CACHE

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -249,7 +249,7 @@ Mergin Maps Input Android on Windows, please help us to update this section.
 1. Setup development environment
    - XCode
    - build tools, see requirements in `.github/workflows/ios.yml`
-   - to install app to your iOS device, you need development certificate
+   - if you want to build for production, you need development certificates. These are not needed for local development, signing is handled automatically (see IOS_USE_PRODUCTION_SIGNING cmake variable for more info). You can get the certificates by following:
        - Get device UDID: either iTunes or about this mac->system report->USB->find iPAD (Serial Number)
        - Create dev iOS certificate for development
        - Create provisioning profile for Input App + your certificate + your device (for this ask Lutra Apple development team)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -362,14 +362,31 @@ if (IOS)
                MACOSX_BUNDLE_GUI_IDENTIFIER "LutraConsultingLtd.Input"
                MACOSX_BUNDLE_SHORT_VERSION_STRING ${INPUT_VERSION}
                MACOSX_BUNDLE_BUNDLE_VERSION ${INPUT_VERSION_CODE}
-               XCODE_ATTRIBUTE_PROVISIONING_PROFILE_SPECIFIER
-               "LutraConsultingLtd.Input.AppStore"
                XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "79QMH2QRAH"
-               XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY
-               "iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)"
-               XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Manual"
                XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
   )
+
+  if (IOS_USE_PRODUCTION_SIGNING)
+
+    # use production signing profile
+    set_target_properties(
+      Input
+      PROPERTIES 
+                XCODE_ATTRIBUTE_PROVISIONING_PROFILE_SPECIFIER "LutraConsultingLtd.Input.AppStore"
+                XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)"
+                XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Manual"
+    )
+    message(STATUS "Using manual code sign with production certificate")
+
+  else ()
+
+    # use development profiles - automatically manage signing
+    set_target_properties(
+      Input
+      PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Automatic"
+    )
+    message(STATUS "Using automatic code sign")
+  endif ()
 endif ()
 
 # ########################################################################################

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -371,20 +371,18 @@ if (IOS)
     # use production signing profile
     set_target_properties(
       Input
-      PROPERTIES 
-                XCODE_ATTRIBUTE_PROVISIONING_PROFILE_SPECIFIER "LutraConsultingLtd.Input.AppStore"
-                XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)"
-                XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Manual"
+      PROPERTIES XCODE_ATTRIBUTE_PROVISIONING_PROFILE_SPECIFIER
+                 "LutraConsultingLtd.Input.AppStore"
+                 XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY
+                 "iPhone Distribution: LUTRA CONSULTING LIMITED (79QMH2QRAH)"
+                 XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Manual"
     )
     message(STATUS "Using manual code sign with production certificate")
 
   else ()
 
     # use development profiles - automatically manage signing
-    set_target_properties(
-      Input
-      PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Automatic"
-    )
+    set_target_properties(Input PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Automatic")
     message(STATUS "Using automatic code sign")
   endif ()
 endif ()


### PR DESCRIPTION
Apple has an option to automatically handle certificates/provisioning profiles. One only needs to be a part of the development team. We want to use this option for local development.

CI will use manual signing.