### PR TITLE
Add support for position tracking for Android versions lower than 12

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
+++ b/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
@@ -164,7 +164,24 @@ public class PositionTrackingService extends Service implements LocationListener
 
         locationManager = ( LocationManager ) getApplication().getSystemService( LOCATION_SERVICE );
 
-        boolean isGPSAvailable = locationManager.isProviderEnabled( LocationManager.FUSED_PROVIDER );
+        if ( Build.VERSION.SDK_INT < Build.VERSION_CODES.O ) {
+            sendStatusUpdateMessage( "ERROR #UNSUPPORTED: tracking is not supported on your Android version ( Android O (8.0) required )" );
+            stopSelf();
+
+            return START_NOT_STICKY; // do not bother recreating it
+        }
+
+        String positionProvider;
+        
+        // FUSED_PROVIDER is available since API 31 (Android 12)
+        if ( Build.VERSION.SDK_INT < Build.VERSION_CODES.S ) {
+            positionProvider = LocationManager.GPS_PROVIDER;
+        }
+        else {
+            positionProvider = LocationManager.FUSED_PROVIDER;
+        }
+
+        boolean isGPSAvailable = locationManager.isProviderEnabled( positionProvider );
         if ( !isGPSAvailable ) {
             sendStatusUpdateMessage( "ERROR #GPS_UNAVAILABLE: GPS is not available!" );
             stopSelf();
@@ -192,7 +209,7 @@ public class PositionTrackingService extends Service implements LocationListener
             }
 
             locationManager.requestLocationUpdates(
-                LocationManager.GPS_PROVIDER,
+                positionProvider,
                 timeInterval,
                 distanceInterval,
                 this

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -203,7 +203,9 @@ ApplicationWindow {
         formsStackManager.reopenAll()
       }
 
-      onNotify: showMessage( message )
+      onNotify: function ( message ) {
+        showMessage( message )
+      }
       onAccuracyButtonClicked: {
         gpsDataPageLoader.active = true
         gpsDataPageLoader.focus = true


### PR DESCRIPTION
FUSED_PROVIDER is available only from SDK level 31 (Android 12). 
Let's use GPS_PROVIDER (available for all versions) in case the FUSED one is not available.

