### PR TITLE
Reduce APK size, add debug symbols to AAB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ app/android/AndroidManifest.xml
 *.gpkg-shm
 Input_keystore.keystore
 CMakeLists.txt.user
+app/android/build.gradle
 app/android/.gradle/*
 app/android/.gradle

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ if (DEFINED ENV{INPUT_SDK_ANDROID_BASE})
   # Target/Minimum API levels for Android, used as Input target properties
   set(INPUT_ANDROID_TARGET_SDK_VERSION "33")
   set(INPUT_ANDROID_MIN_SDK_VERSION "${ANDROIDAPI}")
+  set(INPUT_ANDROID_NDK_PATH "$ENV{ANDROID_NDK_ROOT}")
+  if (NOT INPUT_ANDROID_NDK_PATH)
+    message(FATAL_ERROR "Set required environment variable ANDROID_NDK_ROOT.")
+  endif ()
 endif ()
 
 if (IOS)
@@ -173,7 +177,16 @@ message(STATUS "Mergin Maps Input ${version_desc} - ${platform_desc}")
 
 if (ANDROID)
   set(INPUT_SDK_PATH_ANDROID_ABI_armeabi-v7a ${INPUT_SDK_PATH}/arm-android)
+
+  if (NOT EXISTS ${INPUT_SDK_PATH_ANDROID_ABI_armeabi-v7a})
+    message(WARNING "INPUT_SDK_PATH arm-android directory does not exist!")
+  endif ()
+
   set(INPUT_SDK_PATH_ANDROID_ABI_arm64-v8a ${INPUT_SDK_PATH}/arm64-android)
+  if (NOT EXISTS ${INPUT_SDK_PATH_ANDROID_ABI_arm64-v8a})
+    message(WARNING "INPUT_SDK_PATH arm64-android directory does not exist!")
+  endif ()
+
   set(INPUT_SDK_PATH_MULTI ${INPUT_SDK_PATH_ANDROID_ABI_${ANDROID_ABI}})
   # allow libraries outside of SDK/NDK directory
   set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
@@ -215,7 +228,7 @@ if (NOT IOS)
   )
 endif ()
 
-if (NOT LINUX)
+if (NOT LNX)
   find_package(Charset REQUIRED)
   find_package(Iconv REQUIRED)
 endif ()
@@ -374,10 +387,6 @@ endif ()
 if (IOS)
   # Disabling warnings in qgis qgswkbptr.h
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-shorten-64-to-32")
-endif ()
-
-if (ANDROID)
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g0")
 endif ()
 
 # ########################################################################################

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -297,6 +297,15 @@ if (ANDROID)
     ${INPUT_CMAKE_TEMPLATES_PATH}/AndroidManifest.xml.in
     ${CMAKE_CURRENT_SOURCE_DIR}/android/AndroidManifest.xml @ONLY
   )
+
+  if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/android/build.gradle)
+    file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/android/build.gradle)
+  endif ()
+  configure_file(
+    ${INPUT_CMAKE_TEMPLATES_PATH}/build.gradle.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/android/build.gradle @ONLY
+  )
+
   set_target_properties(
     Input
     PROPERTIES QT_ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/android
@@ -471,7 +480,7 @@ target_link_libraries(
          Spatialite::Spatialite
 )
 
-if (NOT LINUX)
+if (NOT LNX)
   target_link_libraries(Input PUBLIC Charset::Charset Iconv::Iconv)
 endif ()
 

--- a/cmake_templates/build.gradle.in
+++ b/cmake_templates/build.gradle.in
@@ -1,6 +1,13 @@
 /* keep in sync with /opt/Qt/<ver>/android//src/android/templates/build.gradle */
 
 buildscript {
+    ext {
+        buildToolsVersion = androidBuildToolsVersion
+        compileSdkVersion = androidCompileSdkVersion.toInteger()
+        targetSdkVersion = androidCompileSdkVersion.toInteger()
+        ndkVersion = androidNdkVersion
+    }
+    
     repositories {
         google()
         mavenCentral()
@@ -44,7 +51,8 @@ android {
     compileSdkVersion androidCompileSdkVersion.toInteger()
     buildToolsVersion androidBuildToolsVersion
     ndkVersion androidNdkVersion
-
+    ndkPath '@INPUT_ANDROID_NDK_PATH@'
+    
     packagingOptions.jniLibs.useLegacyPackaging true
     
     sourceSets {
@@ -83,6 +91,6 @@ android {
         minSdkVersion qtMinSdkVersion
         targetSdkVersion qtTargetSdkVersion
         ndk.abiFilters = qtTargetAbiList.split(",")
-        ndk.debugSymbolLevel "FULL"
+        ndk.debugSymbolLevel "SYMBOL_TABLE"
     }
 }


### PR DESCRIPTION
Problem1: we do not have native debug symbols in AAB ; fix https://github.com/MerginMaps/input/issues/2147
Problem2: current APKs are now ~500MB, with old build it was ~90MB

**Explanation of the existing situation:**

New vckpg based android SDK is not compiled with `-g` as before (compare https://github.com/MerginMaps/input-sdk/blob/378d1bf861c940fb995ecdfaef9d22b0f4663992/vcpkg-overlay/triplets/arm64-android.cmake#L9 and  https://github.com/MerginMaps/input-sdk/blob/472f8daee008f33a9d08c8c0f51904b114f2306d/android/distribute.sh#L361)

As NDK's cmake toolchain adds it by default (see https://github.com/android/ndk/issues/243) we need to either compile with `-g0` as before for release, or RATHER `stripDebugDebugSymbols` from gradle. This would allow us to have debug symbols too, so it is preferred option

unfortunately we are experiencing the bug similar to this https://github.com/facebook/react-native/issues/32857

**Fix**
- We removed `-g0` from Input build - so now all build types has debug info (as is standard in Android Studio builds - it is stripped by Gradle)
- We added to Gradle.build property `android.ndkPath` which is required to stripDebugSymbols task to work. 
- We changed the debug symbol type to `SYMBOL_TABLE` - size of debug symbol 68 MB (see https://developer.android.com/build/shrink-code), since with `FULL` the native debug symbols zip had 418 MB (above 300 MB limit) ; With this setting we should see all function names of ALL libraries (probably except Qt's, but definitely QGIS, GDAL, etc). We will NOT see line numbers and file-names. If we want to see that for QGIS/Input, we would need to compile input-sdk in a way that selected libraries (let say all but QGIS) will be compiled with `-g0` and without all debug symbols altogether
- currently I checked that APK (unzipped) does not have debug symbol in it, AAB has it included in bundle and all has expected sizes
```
68M build-input-android/app/android-build//build/outputs/native-debug-symbols/release/native-debug-symbols.zip 
118M build-input-android/app/android-build//build/outputs/apk/release/android-build-release-unsigned.apk
187M build-input-android/app/android-build//build/outputs/bundle/release/android-build-release.aab
```
- in case we use sentry.io or other service in future for debug symbols (not uploading them to google play console) we may not be limited by size of the files
