### PR TITLE
Sync. problem when drive space or write permission issue

### DIFF
--- a/app/synchronizationerror.h
+++ b/app/synchronizationerror.h
@@ -31,6 +31,7 @@ class SynchronizationError
       ProjectNotFound,
       VersionMismatch,
       ServerError,
+      FileSystemError,
       UnknownError
     };
     Q_ENUMS( ErrorType );

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -33,6 +33,7 @@ SynchronizationManager::~SynchronizationManager() = default;
 
 void SynchronizationManager::syncProject( const Project &project, SyncOptions::Authorization auth, SyncOptions::Strategy strategy )
 {
+  qInfo() << "xxx SynchronizationManager::syncProject START SYNC" << project.projectName();
   if ( project.isLocal() )
   {
     syncProject( project.local, auth, strategy );
@@ -54,6 +55,8 @@ void SynchronizationManager::syncProject( const Project &project, SyncOptions::A
 
 void SynchronizationManager::syncProject( const LocalProject &project, SyncOptions::Authorization auth, SyncOptions::Strategy strategy )
 {
+  qInfo() << "xxx SynchronizationManager::syncProject" << project.projectName;
+
   if ( !project.isValid() )
   {
     return;
@@ -84,10 +87,12 @@ void SynchronizationManager::syncProject( const LocalProject &project, SyncOptio
 
   if ( ProjectStatus::hasLocalChanges( project ) )
   {
+    qInfo() << "xxx SynchronizationManager::syncProject >> PUSH" << project.projectName;
     syncHasStarted = mMerginApi->pushProject( project.projectNamespace, project.projectName );
   }
   else
   {
+    qInfo() << "xxx SynchronizationManager::syncProject >> PULL" << project.projectName;
     syncHasStarted = mMerginApi->pullProject( project.projectNamespace, project.projectName, auth == SyncOptions::Authorized );
   }
 

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -281,7 +281,7 @@ void SynchronizationManager::onProjectSyncFailure(
 }
 
 // in case of file system error
-void SynchronizationManager::onFileSystemSyncFailure(const QString &message, const QString &projectFullName)
+void SynchronizationManager::onFileSystemSyncFailure( const QString &message, const QString &projectFullName )
 {
   if ( projectFullName.isEmpty() || !mSyncProcesses.contains( projectFullName ) )
   {

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -33,7 +33,6 @@ SynchronizationManager::~SynchronizationManager() = default;
 
 void SynchronizationManager::syncProject( const Project &project, SyncOptions::Authorization auth, SyncOptions::Strategy strategy )
 {
-  qInfo() << "xxx SynchronizationManager::syncProject START SYNC" << project.projectName();
   if ( project.isLocal() )
   {
     syncProject( project.local, auth, strategy );
@@ -55,8 +54,6 @@ void SynchronizationManager::syncProject( const Project &project, SyncOptions::A
 
 void SynchronizationManager::syncProject( const LocalProject &project, SyncOptions::Authorization auth, SyncOptions::Strategy strategy )
 {
-  qInfo() << "xxx SynchronizationManager::syncProject" << project.projectName;
-
   if ( !project.isValid() )
   {
     return;
@@ -87,12 +84,10 @@ void SynchronizationManager::syncProject( const LocalProject &project, SyncOptio
 
   if ( ProjectStatus::hasLocalChanges( project ) )
   {
-    qInfo() << "xxx SynchronizationManager::syncProject >> PUSH" << project.projectName;
     syncHasStarted = mMerginApi->pushProject( project.projectNamespace, project.projectName );
   }
   else
   {
-    qInfo() << "xxx SynchronizationManager::syncProject >> PULL" << project.projectName;
     syncHasStarted = mMerginApi->pullProject( project.projectNamespace, project.projectName, auth == SyncOptions::Authorized );
   }
 

--- a/app/synchronizationmanager.h
+++ b/app/synchronizationmanager.h
@@ -84,6 +84,7 @@ class SynchronizationManager : public QObject
     void onProjectSyncProgressChanged( const QString &projectFullName, qreal progress );
     void onProjectSyncFinished( const QString &projectFullName, bool successfully, int version );
     void onProjectSyncFailure( const QString &message, const QString &topic, int httpCode, const QString &projectFullName );
+    void onFileSystemSyncFailure( const QString &message, const QString &projectFullName );
     void onProjectAttachedToMergin( const QString &projectFullName, const QString &previousName );
     void onProjectReloadNeededAfterSync( const QString &projectFullName );
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1729,7 +1729,7 @@ void MerginApi::finalizeProjectPullCopy( const QString &projectFullName, const Q
     // maybe problem with permissions or drive space
     if ( data.size() != bytesWritten )
     {
-      CoreUtils::log( "writeData ", "Failed to write content into: " + fTmp.fileName() );
+      CoreUtils::log( "finalizeProjectPullCopy ", "Failed to write content into: " + fTmp.fileName() );
       return;
     }
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -244,6 +244,8 @@ void MerginApi::downloadNextItem( const QString &projectFullName )
   Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
   TransactionStatus &transaction = mTransactionalStatus[projectFullName];
 
+  qInfo() << "xxx MerginApi::downloadNextItem" << projectFullName;
+
   if ( transaction.downloadQueue.isEmpty() )
   {
     // there's nothing to download so just finalize the pull
@@ -689,6 +691,8 @@ bool MerginApi::pullProject( const QString &projectNamespace, const QString &pro
 
 bool MerginApi::pushProject( const QString &projectNamespace, const QString &projectName, bool isInitialPush )
 {
+  qInfo() << "xxx MerginApi::pushProject" << projectNamespace << projectName;
+
   QString projectFullName = getFullProjectName( projectNamespace, projectName );
   bool pushHasStarted = false;
 
@@ -1288,6 +1292,8 @@ void MerginApi::onPlanProductIdChanged()
 
 QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, bool withAuth )
 {
+  qInfo() << "xxx MerginApi::getProjectInfo" << projectFullName;
+
   if ( withAuth && !validateAuth() )
   {
     emit missingAuthorizationError( projectFullName );
@@ -1672,6 +1678,7 @@ void MerginApi::listProjectsByNameReplyFinished( QString requestId )
 
 void MerginApi::finalizeProjectPullCopy( const QString &projectFullName, const QString &projectDir, const QString &tempDir, const QString &filePath, const QList<DownloadQueueItem> &items )
 {
+  qInfo() << "xxx MerginApi::finalizeProjectPullCopy" << projectFullName;
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Copying new content of " ) + filePath );
 
   QString dest = projectDir + "/" + filePath;
@@ -1718,6 +1725,7 @@ void MerginApi::finalizeProjectPullCopy( const QString &projectFullName, const Q
 
 bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, const QString &projectDir, const QString &tempDir, const QString &filePath, const QList<DownloadQueueItem> &items )
 {
+  qInfo() << "xxx MerginApi::finalizeProjectPullApplyDiff" << projectFullName;
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Applying diff to " ) + filePath );
 
   // update diffable files that have been modified on the server
@@ -1820,6 +1828,8 @@ void MerginApi::finalizeProjectPull( const QString &projectFullName )
 {
   Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
   TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+
+  qInfo() << "xxx MerginApi::finalizeProjectPull" << projectFullName;
 
   QString projectDir = transaction.projectDir;
   QString tempProjectDir = getTempProjectDir( projectFullName );
@@ -2161,6 +2171,8 @@ void MerginApi::prepareProjectPull( const QString &projectFullName, const QByteA
 
 void MerginApi::startProjectPull( const QString &projectFullName )
 {
+  qInfo() << "xxx MerginApi::startProjectPull" << projectFullName;
+
   Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
   TransactionStatus &transaction = mTransactionalStatus[projectFullName];
 
@@ -2429,6 +2441,8 @@ void MerginApi::pushInfoReplyFinished()
 
   QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
 
+  qInfo() << "xxx MerginApi::pushInfoReplyFinished" << projectFullName;
+
   Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
   TransactionStatus &transaction = mTransactionalStatus[projectFullName];
   Q_ASSERT( r == transaction.replyPushProjectInfo );
@@ -2456,6 +2470,9 @@ void MerginApi::pushInfoReplyFinished()
       CoreUtils::log( "push " + projectFullName, QStringLiteral( "Need pull first: local version %1 | server version %2" )
                       .arg( projectInfo.localVersion ).arg( serverProject.version ) );
       transaction.pullBeforePush = true;
+
+      qInfo() << "xxx MerginApi::pushInfoReplyFinished PULL_BEFORE_PUSH" << projectFullName;
+
       prepareProjectPull( projectFullName, data );
       return;
     }
@@ -2563,6 +2580,10 @@ void MerginApi::pushInfoReplyFinished()
     changes.insert( "removed", removed );
     changes.insert( "updated", modified );
     changes.insert( "renamed", QJsonArray() );
+
+    qInfo() << "xxx MerginApi::pushInfoReplyFinished DELETED FILES" << deletedMerginFiles.length();
+    qInfo() << "xxx MerginApi::pushInfoReplyFinished" << changes;
+    qInfo() << "xxx MerginApi::pushInfoReplyFinished" << changes;
 
     qint64 totalSize = 0;
     for ( MerginFile file : filesToUpload )

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -565,6 +565,11 @@ class MerginApi: public QObject
       const QString &projectFullName = QLatin1String()
     );
 
+    void fileSystemErrorOccurred(
+      const QString &message,
+      const QString &projectFullName = QLatin1String()
+    );
+
     void storageLimitReached( qreal uploadSize );
     void projectLimitReached( int maxProjects, const QString &message );
     void notify( const QString &message );


### PR DESCRIPTION
Stop syncing and write a log message when problem with drive space or write permission.
Fixes: #2382 (hope)
Fixes: https://github.com/MerginMaps/input/issues/2808