### PR TITLE
Profiler

### DIFF
--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -200,9 +200,14 @@ QVector<QString> InputHelp::logHeader( bool isHtml )
   {
     retLines.push_back( QStringLiteral( "%1Mergin User Profile not available. To include it, open you Profile Page in InputApp%2" ).arg( isHtml ? "<b>" : "" ).arg( isHtml ? "</b>" : "" ) );
   }
+  retLines.push_back( QStringLiteral( "------------------------------------------" ) );
   retLines.push_back( QStringLiteral( "Screen Info:" ) );
   retLines.append( InputUtils().dumpScreenInfo().split( "\n" ).toVector() );
   retLines.push_back( QStringLiteral( "------------------------------------------" ) );
+  retLines.push_back( QStringLiteral( "Profiler Data:" ) );
+  retLines.append( InputUtils().qgisProfilerLog() );
+  retLines.push_back( QStringLiteral( "------------------------------------------" ) );
+
   return retLines;
 }
 

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -12,7 +12,6 @@
 #include <QWindow>
 #include <QScreen>
 #include <QApplication>
-#include <QSortFilterProxyModel>
 
 #include "qgsruntimeprofiler.h"
 #include "qcoreapplication.h"

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2004,7 +2004,6 @@ static double qgsRuntimeProfilerExtractModelAsText( QStringList &lines, const QS
   double total_elapsed = 0.0;
 
   const int rc = QgsApplication::profiler()->rowCount( parent );
-  const int cc = QgsApplication::profiler()->columnCount( parent );
   for ( int r = 0; r < rc; r++ )
   {
     QModelIndex rowIndex = QgsApplication::profiler()->index( r, 0, parent );

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1840,7 +1840,6 @@ bool InputUtils::rescaleImage( const QString &path, QgsProject *activeProject )
   return ImageUtils::rescale( path, quality );
 }
 
-
 QgsGeometry InputUtils::createGeometryForLayer( QgsVectorLayer *layer )
 {
   QgsGeometry geometry;
@@ -1919,7 +1918,6 @@ QgsGeometry InputUtils::createGeometryForLayer( QgsVectorLayer *layer )
 
   return geometry;
 }
-
 
 QString InputUtils::invalidGeometryWarning( QgsVectorLayer *layer )
 {
@@ -2012,17 +2010,17 @@ static double qgsRuntimeProfilerExtractModelAsText( QStringList &lines, const QS
   {
     QModelIndex rowIndex = QgsApplication::profiler()->index( r, 0, parent );
     if ( QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Group ).toString() != group )
-        continue;
+      continue;
     bool ok;
-    double elapsed = QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Elapsed ).toDouble(&ok);
-    if (!ok )
-        elapsed = 0.0;
+    double elapsed = QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Elapsed ).toDouble( &ok );
+    if ( !ok )
+      elapsed = 0.0;
     total_elapsed += elapsed;
 
-    if ( elapsed > PROFILER_THRESHOLD)
+    if ( elapsed > PROFILER_THRESHOLD )
     {
-        QString name = QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Name ).toString();
-        lines << QStringLiteral( "%1 %2: %3 sec" ).arg( QStringLiteral( ">" ).repeated( level + 1 ),  name, QString::number(elapsed, 'f', 3) );
+      QString name = QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Name ).toString();
+      lines << QStringLiteral( "  %1 %2: %3 sec" ).arg( QStringLiteral( ">" ).repeated( level + 1 ),  name, QString::number( elapsed, 'f', 3 ) );
     }
     total_elapsed += qgsRuntimeProfilerExtractModelAsText( lines, group, rowIndex, level + 1 );
   }
@@ -2034,21 +2032,22 @@ QVector<QString> InputUtils::qgisProfilerLog()
   QVector<QString> lines;
   const QString project = QgsProject::instance()->fileName();
 
-  if (!project.isEmpty()) {
-    lines << QStringLiteral( "QgsProject filename: %1").arg( project );
+  if ( !project.isEmpty() )
+  {
+    lines << QStringLiteral( "QgsProject filename: %1" ).arg( project );
   }
 
-  lines << QStringLiteral( "List of QgsRuntimeProfiler events above %1 sec").arg( QString::number(PROFILER_THRESHOLD, 'f', 3) );
+  lines << QStringLiteral( "List of QgsRuntimeProfiler events above %1 sec" ).arg( QString::number( PROFILER_THRESHOLD, 'f', 3 ) );
 
   const auto groups = QgsApplication::profiler()->groups();
-  for ( const QString &g : groups)
+  for ( const QString &g : groups )
   {
     QVector<QString> groupLines;
     double elapsed = qgsRuntimeProfilerExtractModelAsText( groupLines, g, QModelIndex(), 0 );
-    if (elapsed > PROFILER_THRESHOLD)
+    if ( elapsed > PROFILER_THRESHOLD )
     {
-        lines << QStringLiteral( "%1: total %2 sec").arg( g, QString::number(elapsed, 'f', 3));
-        lines << groupLines;
+      lines << QStringLiteral( "  %1: total %2 sec" ).arg( g, QString::number( elapsed, 'f', 3 ) );
+      lines << groupLines;
     }
   }
   return lines;

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -12,7 +12,9 @@
 #include <QWindow>
 #include <QScreen>
 #include <QApplication>
+#include <QSortFilterProxyModel>
 
+#include "qgsruntimeprofiler.h"
 #include "qcoreapplication.h"
 #include "qgsgeometrycollection.h"
 #include "qgslinestring.h"
@@ -1997,6 +1999,59 @@ QString InputUtils::layerAttribution( QgsMapLayer *layer )
   }
 
   return QString();
+}
+
+const double PROFILER_THRESHOLD = 0.001;
+static double qgsRuntimeProfilerExtractModelAsText( QStringList &lines, const QString &group, const QModelIndex &parent, int level )
+{
+  double total_elapsed = 0.0;
+
+  const int rc = QgsApplication::profiler()->rowCount( parent );
+  const int cc = QgsApplication::profiler()->columnCount( parent );
+  for ( int r = 0; r < rc; r++ )
+  {
+    QModelIndex rowIndex = QgsApplication::profiler()->index( r, 0, parent );
+    if ( QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Group ).toString() != group )
+        continue;
+    bool ok;
+    double elapsed = QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Elapsed ).toDouble(&ok);
+    if (!ok )
+        elapsed = 0.0;
+    total_elapsed += elapsed;
+
+    if ( elapsed > PROFILER_THRESHOLD)
+    {
+        QString name = QgsApplication::profiler()->data( rowIndex, QgsRuntimeProfilerNode::Name ).toString();
+        lines << QStringLiteral( "%1 %2: %3 sec" ).arg( QStringLiteral( ">" ).repeated( level + 1 ),  name, QString::number(elapsed, 'f', 3) );
+    }
+    total_elapsed += qgsRuntimeProfilerExtractModelAsText( lines, group, rowIndex, level + 1 );
+  }
+  return total_elapsed;
+}
+
+QVector<QString> InputUtils::qgisProfilerLog()
+{
+  QVector<QString> lines;
+  const QString project = QgsProject::instance()->fileName();
+
+  if (!project.isEmpty()) {
+    lines << QStringLiteral( "QgsProject filename: %1").arg( project );
+  }
+
+  lines << QStringLiteral( "List of QgsRuntimeProfiler events above %1 sec").arg( QString::number(PROFILER_THRESHOLD, 'f', 3) );
+
+  const auto groups = QgsApplication::profiler()->groups();
+  for ( const QString &g : groups)
+  {
+    QVector<QString> groupLines;
+    double elapsed = qgsRuntimeProfilerExtractModelAsText( groupLines, g, QModelIndex(), 0 );
+    if (elapsed > PROFILER_THRESHOLD)
+    {
+        lines << QStringLiteral( "%1: total %2 sec").arg( g, QString::number(elapsed, 'f', 3));
+        lines << groupLines;
+    }
+  }
+  return lines;
 }
 
 QList<QgsPoint> InputUtils::parsePositionUpdates( const QString &data )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -299,7 +299,6 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static QString resolvePrefixForRelativePath( int relativeStorageMode, const QString &homePath, const QString &targetDir );
 
-
     /**
      * Returns absolute path of the file for given path and its prefix. If prefixPath is empty,
      * returns given path.
@@ -411,7 +410,6 @@ class InputUtils: public QObject
      * \return Evaluated expression
      */
     Q_INVOKABLE static QString evaluateExpression( const FeatureLayerPair &pair, QgsProject *activeProject, const QString &expression );
-
 
     /**
     * Returns the QVariant typeName of a \a field.
@@ -533,7 +531,7 @@ class InputUtils: public QObject
     Q_INVOKABLE static QString layerAttribution( QgsMapLayer *layer );
 
     /**
-     * Returns QGIS profiler data from loading of last project
+     * Returns QGIS profiler data
      */
     static QVector<QString> qgisProfilerLog();
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -532,6 +532,11 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static QString layerAttribution( QgsMapLayer *layer );
 
+    /**
+     * Returns QGIS profiler data from loading of last project
+     */
+    static QVector<QString> qgisProfilerLog();
+
   signals:
     Q_INVOKABLE void showNotificationRequested( const QString &message );
 


### PR DESCRIPTION
adds to the sticky section of diagnosis log the information from the QgsRuntimeProfiler. Does not show the 0s items. For easier check also reports the loaded QgsProject in the section. 

<img width="635" alt="Screenshot 2023-09-22 at 14 13 34" src="https://github.com/MerginMaps/input/assets/804608/3f544743-f7e3-4280-a7a3-b4c6df130cf6">

