### PR TITLE
Attempt to fix locationManager crash on Android

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
+++ b/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
@@ -83,8 +83,6 @@ public class PositionTrackingService extends Service implements LocationListener
 
     @Override
     public void onDestroy() {
-        super.onDestroy();
-
         locationManager.removeUpdates(this);
 
         // Close the FileOutputStream when the service is destroyed
@@ -96,6 +94,8 @@ public class PositionTrackingService extends Service implements LocationListener
             e.printStackTrace();
             sendStatusUpdateMessage("ERROR #SILENT: Could not close file stream: " + e.getMessage() );
         }
+
+        super.onDestroy();
     }
 
     public void sendStatusUpdateMessage( String message ) {

--- a/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
+++ b/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
@@ -83,7 +83,10 @@ public class PositionTrackingService extends Service implements LocationListener
 
     @Override
     public void onDestroy() {
-        locationManager.removeUpdates(this);
+
+        if (locationManager != null) {
+            locationManager.removeUpdates(this);
+        }
 
         // Close the FileOutputStream when the service is destroyed
         try {


### PR DESCRIPTION
Moved the call to parent destructor to the last line and added a check if the `locationManager` is already NULL.
Though it is not clear why it would be NULL

https://app.clickup.com/t/862ke67ea