### PR TITLE
Removed Qt.inputMethod.commit() for tests

### DIFF
--- a/app/qml/components/NumberInputField.qml
+++ b/app/qml/components/NumberInputField.qml
@@ -36,8 +36,6 @@ Item {
       }
     }
 
-    onPreeditTextChanged: if ( __androidUtils.isAndroid ) Qt.inputMethod.commit() // to avoid Android's uncommited text
-
     text: root.number
 
     height: parent.height

--- a/app/qml/editor/inputtextedit.qml
+++ b/app/qml/editor/inputtextedit.qml
@@ -70,7 +70,5 @@ AbstractEditor {
 
       editorValueChanged( val, val === "" )
     }
-
-    onPreeditTextChanged: if ( __androidUtils.isAndroid ) Qt.inputMethod.commit() // to avoid Android's uncommited text
   }
 }

--- a/app/qml/editor/inputtexteditmultiline.qml
+++ b/app/qml/editor/inputtexteditmultiline.qml
@@ -45,7 +45,5 @@ AbstractEditor {
     }
 
     onTextChanged: root.editorValueChanged( text, text === "" )
-
-    onPreeditTextChanged: Qt.inputMethod.commit() // to avoid Android's uncommited text
   }
 }

--- a/app/qml/form/FeatureForm.qml
+++ b/app/qml/form/FeatureForm.qml
@@ -621,13 +621,6 @@ Item {
   }
 
   Connections {
-    target: Qt.inputMethod
-    function onVisibleChanged() {
-      Qt.inputMethod.commit()
-    }
-  }
-
-  Connections {
     target: form.controller
     function onChangesCommited() {
       form.saved()


### PR DESCRIPTION
Just for tests, if it is needed to use Qt.inputMethod.commit() method