### PR TITLE
fix crash with broken relations

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -223,7 +223,7 @@ void AttributeController::flatten(
         int fieldIndex = editorField->idx();
         if ( fieldIndex < 0 || fieldIndex >= layer->fields().size() )
         {
-          qDebug() << "Invalid fieldIndex for editorField!";
+          CoreUtils::log( "Forms", QStringLiteral( "Invalid fieldIndex for editorField in layer %1" ).arg( layer->name() ) );
           continue;
         }
         QgsField field = layer->fields().at( fieldIndex );
@@ -269,10 +269,17 @@ void AttributeController::flatten(
         QgsAttributeEditorRelation *relationField = static_cast<QgsAttributeEditorRelation *>( element );
         QgsRelation associatedRelation = relationField->relation();
 
+        bool isValid = associatedRelation.isValid();
+        if ( !isValid )
+        {
+          CoreUtils::log( "Relations", QStringLiteral( "Ignoring invalid relation in layer %1" ).arg( layer->name() ) );
+          continue;
+        }
+
         bool isNmRelation = layer->editFormConfig().widgetConfig( associatedRelation.id() )[QStringLiteral( "nm-rel" )].toBool();
         if ( isNmRelation )
         {
-          CoreUtils::log( "Relations", "Nm relations are not supported" );
+          CoreUtils::log( "Relations", QStringLiteral( "Nm relations are not supported in layer %1" ).arg( layer->name() ) );
           continue;
         }
 


### PR DESCRIPTION
fix https://github.com/MerginMaps/input/issues/1905
fix https://github.com/MerginMaps/input/issues/2569 (no test case attached so hard to test)

fix CU-862ke6fkg
fix CU-862ke6jx6

For test suite - I think it is such an edge case that it may not be worth to add it to regular test suite (automatic or manual). Better to add validation to plugin https://github.com/MerginMaps/qgis-mergin-plugin/issues/298 for this case and caught it early

it is now possible to identify crashing feature `b39` from [lutraconsulting/issue_1905](https://public.cloudmergin.com/projects/lutraconsulting/issue_1905/tree)

![Screenshot 2023-09-25 at 15 58 13](https://github.com/MerginMaps/input/assets/804608/6f2de11e-77e6-49c2-9e0f-3d4895afb098)

and the diagnostics log shows the error 
![Screenshot 2023-09-25 at 15 46 16](https://github.com/MerginMaps/input/assets/804608/0e57be98-69b3-41d1-8783-661462658ae3)

