### PR TITLE
fix crash ios gallery

### DIFF
--- a/app/ios/iosinterface.mm
+++ b/app/ios/iosinterface.mm
@@ -210,7 +210,12 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
     // Confirm event
     delegate->imagePickerControllerDidFinishPickingMediaWithInfo = ^( UIImagePickerController * picker, NSDictionary * info )
     {
-      Q_UNUSED( picker )
+      if ( delegate->processingPicture )
+      {
+        qWarning() << "Image Picker: Already processing other photo (imagePickerControllerDidFinishPickingMediaWithInfo)";
+        return;
+      }
+      delegate->processingPicture = YES;
 
       NSString *imagePath = generateImagePath( delegate->handler->targetDir().toNSString() );
       QString err;
@@ -244,7 +249,6 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
                                    Q_ARG( bool, err.isEmpty() ),
                                    Q_ARG( const QVariantMap, data ) );
       }
-      delegate = nil;
     };
 
 

--- a/app/ios/iosviewdelegate.h
+++ b/app/ios/iosviewdelegate.h
@@ -28,6 +28,7 @@ UINavigationControllerDelegate>
   @public
 
   IOSImagePicker *handler;
+  BOOL processingPicture;
 
   void ( ^ imagePickerControllerDidFinishPickingMediaWithInfo )( UIImagePickerController * picker, NSDictionary * info );
   void ( ^ imagePickerControllerDidCancel )( UIImagePickerController * picker );

--- a/app/ios/iosviewdelegate.mm
+++ b/app/ios/iosviewdelegate.mm
@@ -27,6 +27,7 @@
   self = [super init];
   if ( self )
   {
+    self->processingPicture = NO;
     self->handler = handler;
   }
   return self;


### PR DESCRIPTION
fix https://github.com/MerginMaps/input/issues/1540
fix CU-862keccax

it looks like if the user is really quick he can select another photo in the gallery when the first one is being processed in `imagePickerControllerDidFinishPickingMediaWithInfo` and unfortunately I do not see a way to hide that dialog fast enough. The view delegate is not reused between 2 select/capture actions so I added `BOOL` to block the second (another) selection while the first one is being proceeded. 