### PR TITLE
Revamp mapcanvas gesture handlers & fix propagation issues

### DIFF
--- a/app/qml/CMakeLists.txt
+++ b/app/qml/CMakeLists.txt
@@ -73,7 +73,7 @@ set(MM_QML
     map/Crosshair.qml
     map/Highlight.qml
     map/LoadingIndicator.qml
-    map/MapCanvas.qml
+    map/MMMapCanvas.qml
     map/MapWrapper.qml
     map/PositionMarker.qml
     map/RecordingToolbar.qml

--- a/app/qml/NumberSpin.qml
+++ b/app/qml/NumberSpin.qml
@@ -73,9 +73,11 @@ Item {
       width: imageDecrease.width * 3
       height: imageDecrease.height * 3
 
-      TapHandler {  
-        onTapped: function(eventPoint, button) {
-            if (minValue <= root.value - 1) root.value -=1
+      MouseArea {
+        anchors.fill: parent
+
+        onClicked: {
+          if (minValue <= root.value - 1) root.value -=1
         }
       }
     }
@@ -86,9 +88,11 @@ Item {
       width: imageIncrease.width * 3
       height: imageIncrease.height * 3
 
-      TapHandler {
-        onTapped: function(eventPoint, button) {
-            if (maxValue >= root.value + 1) root.value +=1
+      MouseArea {
+        anchors.fill: parent
+
+        onClicked: {
+          if (maxValue >= root.value + 1) root.value +=1
         }
       }
     }

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -114,8 +114,10 @@ Item {
               onCheckedChanged: __appSettings.autoCenterMapChecked = checked
             }
 
-            TapHandler {
-              onTapped: function(eventPoint, button) {
+            MouseArea {
+              anchors.fill: parent
+
+              onClicked: {
                 autoCenterMapSwitch.toggle()
               }
             }
@@ -217,8 +219,10 @@ Item {
               onCheckedChanged: __appSettings.gpsAccuracyWarning = checked
             }
 
-            TapHandler {
-              onTapped: function(eventPoint, button) {
+            MouseArea {
+              anchors.fill: parent
+
+              onClicked: {
                 accuracyWarningSwitch.toggle()
               }
             }
@@ -300,8 +304,10 @@ Item {
               onCheckedChanged: __appSettings.reuseLastEnteredValues = checked
             }
 
-            TapHandler {
-              onTapped: function(eventPoint, button) {
+            MouseArea {
+              anchors.fill: parent
+
+              onClicked: {
                 rememberValuesSwitch.toggle()
               }
             }
@@ -320,8 +326,10 @@ Item {
               onCheckedChanged: __appSettings.autosyncAllowed = checked
             }
 
-            TapHandler {
-              onTapped: function(eventPoint, button) {
+            MouseArea {
+              anchors.fill: parent
+
+              onClicked: {
                 autosyncSwitch.toggle()
               }
             }

--- a/app/qml/components/MainPanelButton.qml
+++ b/app/qml/components/MainPanelButton.qml
@@ -38,14 +38,16 @@ Rectangle {
         anchors.fill: parent
         enabled: root.enabled && handleClicks
 
-        TapHandler {
-            onTapped: function(eventPoint, button) {
-                root.activated()
-            }
+        MouseArea {
+          anchors.fill: parent
 
-            onLongPressed: {
-                root.activatedOnHold()
-            }
+          onClicked: {
+            root.activated()
+          }
+
+          onPressAndHold: {
+            root.activatedOnHold()
+          }
         }
     }
 

--- a/app/qml/components/MapFloatButton.qml
+++ b/app/qml/components/MapFloatButton.qml
@@ -50,12 +50,14 @@ Item {
     Item {
       anchors.fill: parent
       
-      TapHandler {
-        onTapped: function(eventPoint, button) {
+      MouseArea {
+        anchors.fill: parent
+
+        onClicked: {
           root.clicked()
         }
 
-        onLongPressed: function() {
+        onPressAndHold: {
           root.pressAndHold()
         }
       }

--- a/app/qml/editor/AbstractEditor.qml
+++ b/app/qml/editor/AbstractEditor.qml
@@ -60,11 +60,11 @@ Item {
         x: leftActionContainer.actionAllowed ? parent.x - customStyle.fields.sideMargin : parent.x
         height: parent.height
 
-        TapHandler {
-          onPressedChanged: {
-            if ( !pressed ) {
-              root.leftActionClicked()
-            }
+        MouseArea {
+          anchors.fill: parent
+
+          onReleased: {
+            root.leftActionClicked()
           }
         }
       }
@@ -79,8 +79,10 @@ Item {
       height: parent.height
       width: parent.width - ( leftActionContainer.width + rightActionContainer.width )
 
-      TapHandler {
-        onSingleTapped: {
+      MouseArea {
+        anchors.fill: parent
+
+        onClicked: {
           root.contentClicked()
         }
       }
@@ -101,11 +103,11 @@ Item {
         width: rightActionContainer.actionAllowed ? parent.width + customStyle.fields.sideMargin : parent.width
         height: parent.height
 
-        TapHandler {
-          onPressedChanged: {
-            if ( !pressed ) {
-              root.rightActionClicked()
-            }
+        MouseArea {
+          anchors.fill: parent
+
+          onReleased: {
+            root.rightActionClicked()
           }
         }
       }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -147,21 +147,6 @@ ApplicationWindow {
           // if feature preview panel is opened
           return formsStackManager.takenVerticalSpace - mainPanel.height
         }
-        else if ( stateManager.state === "projects" || stateManager.state === "misc" )
-        {
-          //
-          // Due to an upstream bug in Qt, see #2387 and #2425 for more info
-          //
-          return window.height
-        }
-        else if ( gpsDataPageLoader.active )
-        {
-          //
-          // Block also GPS data page clicks propagation.
-          // Due to an upstream bug in Qt, see #2387 and #2425 for more info
-          //
-          return window.height
-        }
 
         return 0
       }
@@ -252,11 +237,6 @@ ApplicationWindow {
 
         width: window.width
         height: InputStyle.rowHeightHeader
-
-        //
-        // In order to workaround the QTBUG-108689 - we need to disable main panel's buttons when something else occupies the space
-        //
-        enabled: mainPanel.height > map.mapExtentOffset
 
         y: window.height - height
 

--- a/app/qml/map/MMMapCanvas.qml
+++ b/app/qml/map/MMMapCanvas.qml
@@ -7,11 +7,6 @@
  *                                                                         *
  ***************************************************************************/
 
-/*
- * Previous implementation was forked from https://github.com/qgis/QGIS on 25th Nov 2022
- * File: qgsquickmapcanvas.qml by (C) 2014 by Matthias Kuhn
- */
-
 import QtQuick
 import QtCore
 import QtQuick.Controls

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -199,7 +199,7 @@ Item {
         anchors.fill: parent
       }
 
-      MapCanvas {
+      MMMapCanvas {
         id: mapCanvas
 
         anchors.fill: canvasRoot

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -204,19 +204,6 @@ Item {
 
         anchors.fill: canvasRoot
 
-        /**
-         * We need to do a little hack here.
-         * Qt 6.4.1 falsely propagates events to all handlers event if the mouse event is accepted.
-         * Thus, mouse clicks were propagated to map canvas even if feature form was opened -
-         * resulting in undefined behaviour.
-         *
-         * As a workaround, we pass mapExtentOffset to map canvas and alter the TapHandler's height based on it.
-         * This way canvas still reacts to clicks when form is opened in preview.
-         *
-         * See https://bugreports.qt.io/browse/QTBUG-108821
-         */
-        mapExtentOffset: root.mapExtentOffset
-
         mapSettings.project: __activeProject.qgsProject
 
         IdentifyKit {

--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -62,7 +62,7 @@ Item {
 
         if ( !isNaN( newCenter.x ) && !isNaN( newCenter.y ) )
         {
-          root.map.moveTo( /*crosshair.screenPoint,*/ root.map.mapSettings.coordinateToScreen( newCenter ) )
+          root.map.jumpTo( /*crosshair.screenPoint,*/ root.map.mapSettings.coordinateToScreen( newCenter ) )
         }
       }
     }


### PR DESCRIPTION
This PR is a complete rewrite of MapCanvas gesture handlers. 
Due to multiple issues in Qt (like QTBUG-108689, QTBUG-108821 and more..), `TapHandlers`, `DragHandlers` and `PinchHandlers` were a pain to use and maintain.
 - they were fighting who should get an exclusive grab (often resulting in no one and frozen UI)
 - taps were propagated to parent scopes even though they should not

The new implementation is minimal and contains only `PinchArea` with nested `MouseArea`. Drags and double-clicks are implemented on our own now. 

**Important: we no longer support tap&drag gesture to zoom in/out the map**. 
If needed, it will not be hard to add it to the current implementation though 

There are still some bits and pieces needed to get rid of the propagation issues (will be a part of this PR):
 - [x] replace `TapHandler`s with `MouseArea`s everywhere (@iiLubos)
 - [x] get rid of the remaining code used as a workaround for the mentioned issues

We need quite a massive testing to make sure the map gestures work properly 😏

Fixes #2549 
Fixes #2683 
Fixes #2684 
Fixes #2617 