### PR TITLE
Fix text overflow in preview panel

### DIFF
--- a/app/qml/form/PreviewPanel.qml
+++ b/app/qml/form/PreviewPanel.qml
@@ -190,7 +190,7 @@ Item {
                         Text {
                             id: fieldName
                             text: Name
-                            width: root.width/2
+                            width: root.width / 2
                             font.pixelSize: InputStyle.fontPixelSizeNormal
                             color: InputStyle.fontColorBright
                             elide: Text.ElideRight
@@ -199,6 +199,7 @@ Item {
                         Text {
                             id: fieldValue
                             text: Value ? Value : ""
+                            width: root.width / 2 - root.spacing
                             font.pixelSize: InputStyle.fontPixelSizeNormal
                             color: InputStyle.fontColor
                             elide: Text.ElideRight


### PR DESCRIPTION
Fixed overflow in the preview panel of `fields` type.


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/MerginMaps/input/assets/22449698/02ad01d5-7b12-49b6-8c5b-6a474149f105" width="300"/></td>
    <td><img src="https://github.com/MerginMaps/input/assets/22449698/8dded5bc-1ea8-4833-8363-613c7e868801"  width="300"/></td>
  </tr>
 </table>
