### PR TITLE
Enable swipe gesture in forms to switch between tabs

### DIFF
--- a/app/qml/form/FeatureForm.qml
+++ b/app/qml/form/FeatureForm.qml
@@ -276,12 +276,6 @@ Item {
       id: swipeView
       currentIndex: form.controller.hasTabs ? tabRow.currentIndex : 0
 
-      //
-      // Known limitation, we can not make swipeview interactive because of https://bugreports.qt.io/browse/QTBUG-109124
-      // It clashes with slider editors, see https://github.com/MerginMaps/input/issues/2411
-      //
-      interactive: false
-
       anchors {
         top: flickable.bottom
         left: container.left


### PR DESCRIPTION
We disabled this gesture previously because of a QT bug, but it seems to be fixed now.

The issue was that previously `SwipeView` used to steal grab from `Slider`, see video in the related QT bug: https://bugreports.qt.io/browse/QTBUG-109124

Note: Even though the related QT bug is not closed, this seems to be working

https://github.com/MerginMaps/input/assets/22449698/77daf939-13ff-461a-bc4c-54e47676c120

Fixes #2473 
Related #2675 