### PR TITLE
calendar widget fixes

### DIFF
--- a/app/qml/components/DateTimePicker.qml
+++ b/app/qml/components/DateTimePicker.qml
@@ -392,7 +392,17 @@ Item {
               MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                  calendar.selectDate(model.date)
+                  let pickedDate = new Date( model.year, model.month, model.day);
+                  // Do NOT use model.date!!
+                  // see https://bugreports.qt.io/browse/QTBUG-72208
+                  // For some timezones model.date.getDate() != model.day
+                  // e.g. you are in timezone TZ=America/Mexico_City
+                  // model.date: Wed Oct 11 18:00:00 2023 GMT-0600
+                  // model.day: 12
+                  // model.date.getDate(): 11
+                  // pickedDate Thu Oct 12 00:00:00 2023 GMT-0600
+                  // pickedDate.getDate(): 12
+                  calendar.selectDate(pickedDate)
                 }
               }
             }

--- a/app/qml/editor/inputdatetime.qml
+++ b/app/qml/editor/inputdatetime.qml
@@ -195,7 +195,17 @@ AbstractEditor {
 
         onSelected: function( selectedDate ) {
           if ( selectedDate )
-            root.editorValueChanged(selectedDate, false)
+          {
+            if ( root.parentField.isDateOrTime )
+            {
+              root.editorValueChanged(selectedDate, false)
+            }
+            else
+            {
+              let dateStr = selectedDate.toLocaleString(Qt.locale(), config['field_format'])
+              root.editorValueChanged(dateStr, false)
+            }
+          }
 
           dateTimeDrawer.close()
         }


### PR DESCRIPTION
CU-862kf11u9

1/ fix #1671 wrong calendar day with 

- Run app (deskop) with ENV: TZ=America/Mexico_City
- Left fixed app ; Right - current app
- Reason: https://bugreports.qt.io/browse/QTBUG-72208 `model.date` returns wrong date in different timezones

https://github.com/MerginMaps/input/assets/804608/9c531d57-eac2-4632-885c-392cac4995de

2/ fix #2827 wrong calendar pick with text field 


https://github.com/MerginMaps/input/assets/804608/2919b7cb-ff75-4ba5-9df4-6f271767315b



Testing project @jozef-budac 
- (public): https://app.merginmaps.com/projects/peter.petrik/test-date-picker 
- for testing 1/ you need to go to timezone with at least -6GTM (e.g. Mexico_City!)



