### PR TITLE
Use new storage permissions on Android >13

### DIFF
--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -157,7 +157,19 @@ void AndroidUtils::quitApp()
 bool AndroidUtils::requestStoragePermission()
 {
 #ifdef ANDROID
-  if ( !checkAndAcquirePermissions( "android.permission.READ_EXTERNAL_STORAGE" ) )
+  double buildVersion = QSysInfo::productVersion().toDouble();
+
+  //
+  // Android SDK 33 has a new set of permissions when reading external storage.
+  // See https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE
+  //
+  QString storagePermissionType = QStringLiteral( "android.permission.READ_MEDIA_IMAGES" );
+  if ( buildVersion < ANDROID_VERSION_13 )
+  {
+    storagePermissionType = QStringLiteral( "android.permission.READ_EXTERNAL_STORAGE" );
+  }
+
+  if ( !checkAndAcquirePermissions( storagePermissionType ) )
   {
     auto activity = QJniObject( QNativeInterface::QAndroidApplication::context() );
     jboolean res = activity.callMethod<jboolean>( "shouldShowRequestPermissionRationale", "(Ljava/lang/String;)Z", QJniObject::fromString( "android.permission.WRITE_EXTERNAL_STORAGE" ).object() );

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -70,6 +70,8 @@ class AndroidUtils: public QObject
     const static int INSTALL_QR_SCANNER_CODE = 104;
     const static int QR_SCAN_CODE = 105;
 
+    const static int ANDROID_VERSION_13 = 13;
+
     void handleActivityResult( int receiverRequestCode, int resultCode, const QJniObject &data ) override;
 #endif
 

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -5,14 +5,15 @@
     android:versionCode="@INPUT_VERSION_CODE@"
     android:versionName="@INPUT_VERSION@">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/> <!-- Need due to a legacy storage migration -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/> <!-- Read images from gallery, Android <=12 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/> <!-- Read images from gallery, Android 13+ -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" /> <!-- BT permission up to SDK 30-->
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" /> <!-- BT permission up to SDK 30-->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/> <!-- Reading compass while taking a picture -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
@@ -31,13 +32,11 @@
         android:largeScreens="true"
         android:normalScreens="true"
         android:smallScreens="true" />
-    <!-- "preserveLegacyExternalStorage" is needed to support legacy storage migration -->
     <!-- "allowBackup" is suspicious, see https://developer.android.com/guide/topics/manifest/application-element#allowbackup -->
     <application 
         android:name="org.qtproject.qt.android.bindings.QtApplication"
         android:hardwareAccelerated="true"
         android:label="Mergin Maps"
-        android:preserveLegacyExternalStorage="true" 
         android:allowNativeHeapPointerTagging="false"
         android:allowBackup="true"
         android:fullBackupOnly="false"


### PR DESCRIPTION
Android introduced a new set of storage permission types. 
From API level 33 (Android version 13.0), we can not request `READ_EXTERNAL_STORAGE` to get photos from the gallery, but `READ_MEDIA_IMAGES` instead.

Fixes the issue that user can not pick image from gallery on android >13 (CU-862keem0n)

See https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE