### PR TITLE
Ask for notification permission

### DIFF
--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -91,6 +91,34 @@ QString AndroidUtils::externalStorageAppFolder()
   return QString();
 }
 
+bool AndroidUtils::requestNotificationPermission()
+{
+#ifdef ANDROID
+  double buildVersion = QSysInfo::productVersion().toDouble();
+
+  // POST_NOTIFICATIONS permission is available from Android 13+
+  if ( buildVersion < ANDROID_VERSION_13 )
+  {
+    return true;
+  }
+
+  QString notificationPermission = QStringLiteral( "android.permission.POST_NOTIFICATIONS" );
+
+  auto r = QtAndroidPrivate::checkPermission( notificationPermission ).result();
+  if ( r == QtAndroidPrivate::Authorized )
+  {
+    return true;
+  }
+
+  r = QtAndroidPrivate::requestPermission( notificationPermission ).result();
+  if ( r == QtAndroidPrivate::Authorized )
+  {
+    return true;
+  }
+#endif
+  return false;
+}
+
 QString AndroidUtils::readExif( const QString &filePath, const QString &tag )
 {
 #ifdef ANDROID

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -36,6 +36,9 @@ class AndroidUtils: public QObject
 
     static QString externalStorageAppFolder();
 
+    // Android 13+ needs permission for sending notifications
+    static bool requestNotificationPermission();
+
     /**
      * Reads EXIF and returns value for given parameters.
      * @param filePath Absolute path to a file

--- a/app/position/tracking/androidtrackingbackend.cpp
+++ b/app/position/tracking/androidtrackingbackend.cpp
@@ -11,6 +11,7 @@
 #include "androidtrackingbroadcast.h"
 #include "coreutils.h"
 #include "inpututils.h"
+#include "androidutils.h"
 
 #include <QtCore/private/qandroidextras_p.h>
 
@@ -189,8 +190,14 @@ void AndroidTrackingBackend::setupForegroundUpdates()
     &AndroidTrackingBackend::sourceUpdatedState
   );
 
-  // TODO: you need to check if this is starting tracking or just resuming
-  // It should not be an issue to start this if it is already running, but let's double check
+  // We need to ask for a permission to show notifications,
+  // but it is not mandatory to start the foreground service
+  // See: https://developer.android.com/develop/ui/views/notifications/notification-permission
+  if ( !AndroidUtils::requestNotificationPermission() )
+  {
+    emit errorOccured( tr( "Enable notifications to see tracking in the notifications tray" ) );
+    CoreUtils::log( QStringLiteral( "Android Tracking Backend" ), QStringLiteral( "Notifications are disabled" ) );
+  }
 
   auto activity = QJniObject( QNativeInterface::QAndroidApplication::context() );
   QAndroidIntent serviceIntent( activity.object(), "uk/co/lutraconsulting/PositionTrackingService" );

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/> <!-- Reading compass while taking a picture -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/> <!-- To be able to send notifications, Android 13+ -->
 
     <!-- Android considers EXIF data as sensitive (since they contain user's location), so we need to opt for permission ACCESS_MEDIA_LOCATION.
     Even though it is a runtime permission (one need to opt for it in code),


### PR DESCRIPTION
Android system notification for tracking won't be visible on Android 13+ unless we ask for specific permission (`POST_NOTIFICATIONS`).

This permission is not needed to start the service, so it is up to a user if they want to see the tracking in the notifications tray or not.
See https://developer.android.com/develop/ui/views/notifications/notification-permission

Resolves #2833 