### PR TITLE
fix photo in relation preview 

### DIFF
--- a/app/relationfeaturesmodel.cpp
+++ b/app/relationfeaturesmodel.cpp
@@ -112,12 +112,12 @@ QgsRelation RelationFeaturesModel::relation() const
 
 QVariant RelationFeaturesModel::relationPhotoPath( const FeatureLayerPair &featurePair ) const
 {
-  // Feature title used to get path of the referenced image.
-  QString path = featureTitle( featurePair ).toString();
-
   int fieldIndex = photoFieldIndex( featurePair.layer() );
   QgsEditorWidgetSetup setup = featurePair.layer()->editorWidgetSetup( fieldIndex );
   QVariantMap config = setup.config();
+
+  const QgsFeature feature = featurePair.feature();
+  QString path = feature.attribute( fieldIndex ).toString();
 
   QString finalPath = InputUtils::resolvePath( path, homePath(), config, featurePair, QgsProject::instance() );
 
@@ -126,6 +126,10 @@ QVariant RelationFeaturesModel::relationPhotoPath( const FeatureLayerPair &featu
 
 int RelationFeaturesModel::photoFieldIndex( QgsVectorLayer *layer ) const
 {
+  if ( !layer )
+  {
+    return -1;
+  }
 
   QgsFields fields = layer->fields();
   for ( int i = 0; i < fields.size(); i++ )


### PR DESCRIPTION
fix #2058
fix https://github.com/MerginMaps/input/issues/2586

project `support/BugZapper2058` or any project where photo photo field is not set as layer display field (usually when user does does not have photo widget as second in the form)

![Screenshot 2023-10-16 at 15 07 48](https://github.com/MerginMaps/input/assets/804608/c866f2fb-7cd4-44b9-b1f8-eaa66b236e8c)
 