### PR TITLE
 conditional visibility of the relation widget

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -302,6 +302,7 @@ void AttributeController::flatten(
               parentTabRow,
               FormItem::Relation,
               label,
+              parentVisibilityExpressions, // relation field doesn't have visibility expression itself
               associatedRelation
             )
           );

--- a/app/attributes/attributedata.cpp
+++ b/app/attributes/attributedata.cpp
@@ -71,14 +71,14 @@ FormItem *FormItem::createFieldItem(
          );
 }
 
-FormItem *FormItem::createRelationItem(
-  const QUuid &id,
-  const QString &groupName,
-  int parentTabId,
-  FormItemType type,
-  const QString &name,
-  const QgsRelation &relation
-)
+FormItem *FormItem::createRelationItem( const QUuid &id,
+                                        const QString &groupName,
+                                        int parentTabId,
+                                        FormItemType type,
+                                        const QString &name,
+                                        const QgsExpression &visibilityExpression,
+                                        const QgsRelation &relation
+                                      )
 {
   FormItem *item = new FormItem(
     id,
@@ -90,7 +90,7 @@ FormItem *FormItem::createRelationItem(
     true,
     QgsEditorWidgetSetup(),
     -1,
-    QgsExpression(),
+    visibilityExpression,
     relation
   );
   return item;

--- a/app/attributes/attributedata.h
+++ b/app/attributes/attributedata.h
@@ -81,6 +81,7 @@ class FormItem
       int parentTabId,
       FormItem::FormItemType type,
       const QString &name,
+      const QgsExpression &visibilityExpression,
       const QgsRelation &relation
     );
 


### PR DESCRIPTION
fix #2712
fix #2098

before/released v2.3.0:
![conditional_visibility-bad](https://github.com/MerginMaps/input/assets/804608/03f9b660-66e5-4472-9bac-fecca6b82bd2)


after this fix:

https://github.com/MerginMaps/input/assets/804608/d48142a3-2d2b-4a3b-9838-267ce7628c0c



