### PR TITLE
Fix mapcanvas UX issues

### DIFF
--- a/app/qml/map/MMMapCanvas.qml
+++ b/app/qml/map/MMMapCanvas.qml
@@ -31,9 +31,6 @@ Item {
   property alias mapSettings: mapRenderer.mapSettings
   property alias isRendering: mapRenderer.isRendering
 
-  // Number of miliseconds to differentiate between normal click (select feature) and double-click (zoom)
-  property int doubleClickThresholdMilis: 350
-
   // Requests map redraw
   function refresh() {
     mapRenderer.clearCache()
@@ -166,17 +163,14 @@ Item {
       onPressed: function ( mouse ) {
         initialPosition = Qt.point( mouse.x, mouse.y )
         rendererPrivate.freeze( mouseArea.freezeId )
+
+        dragDifferentiatorTimer.start()
       }
 
       onReleased: function ( mouse ) {
         let clickPosition = Qt.point( mouse.x, mouse.y )
 
-        if ( !clickDifferentiatorTimer.running ) {
-          // this is a simple click
-
-          clickDifferentiatorTimer.clickedPoint = Qt.point( mouse.x, mouse.y )
-        }
-        else {
+        if ( clickDifferentiatorTimer.running ) {
           //
           // n-th click in a row (second, third,..)
           // this can be double click if it is in a reasonable
@@ -193,14 +187,20 @@ Item {
 
           if ( isDoubleClick ) {
             // do not emit clicked signal when zooming
-            clickDifferentiatorTimer.invalidate = true
+            clickDifferentiatorTimer.ignoreNextTrigger = true
 
             mapRenderer.zoom( Qt.point( mouse.x, mouse.y ), 0.4 )
           }
-        }
 
-        if ( !isDragging ) {
           clickDifferentiatorTimer.restart()
+        }
+        else if ( !isDragging )
+        {
+          // this is a simple click
+
+          clickDifferentiatorTimer.clickedPoint = clickPosition
+          clickDifferentiatorTimer.ignoreNextTrigger = false // just in case
+          clickDifferentiatorTimer.start()
         }
 
         previousPosition = null
@@ -208,11 +208,13 @@ Item {
         isDragging = false
 
         rendererPrivate.unfreeze( mouseArea.freezeId )
+
+        dragDifferentiatorTimer.stop()
       }
 
       onPressAndHold: function ( mouse ) {
         mapRoot.longPressed( Qt.point( mouse.x, mouse.y ) )
-        clickDifferentiatorTimer.invalidate = true
+        clickDifferentiatorTimer.ignoreNextTrigger = true
       }
 
       onWheel: function ( wheel ) {
@@ -242,14 +244,27 @@ Item {
 
         previousPosition = target
 
-        let dragDistance = rendererPrivate.vectorDistance( initialPosition, target )
+        if ( !isDragging ) {
+          // do not compute if we are already dragging
 
-        // TODO: we need a high-precision mode here
-        if ( dragDistance > mouseArea.drag.threshold ) {
-          isDragging = true
+          let dragDistance = rendererPrivate.vectorDistance( initialPosition, target )
 
-          // do not emit click after drag
-          clickDifferentiatorTimer.reset()
+          if ( dragDistance > Application.styleHints.startDragDistance ) {
+            // Drag distance threshold is hit, this is dragging!
+            isDragging = true
+          }
+
+          if ( !dragDifferentiatorTimer.running ) {
+            // User is panning the map for too long (timer already elapsed), this is dragging now!
+            isDragging = true
+          }
+
+          if ( isDragging ) {
+            // do not emit click after drag
+
+            clickDifferentiatorTimer.stop()
+            clickDifferentiatorTimer.ignoreNextTrigger = false
+          }
         }
       }
 
@@ -264,30 +279,32 @@ Item {
         previousPosition = null
         initialPosition = null
         isDragging = false
+
         rendererPrivate.unfreeze( mouseArea.freezeId )
+        dragDifferentiatorTimer.stop()
       }
 
       Timer {
         id: clickDifferentiatorTimer
 
         property var clickedPoint
-        property bool invalidate
+        property bool ignoreNextTrigger
 
-        interval: mapRoot.doubleClickThresholdMilis
-        repeat: false
+        interval: Application.styleHints.mouseDoubleClickInterval
 
         onTriggered: {
-          if ( !invalidate ) {
+          if ( !ignoreNextTrigger ) {
             mapRoot.clicked( clickedPoint )
           }
-          invalidate = false
+          ignoreNextTrigger = false
           clickedPoint = null
         }
+      }
 
-        function reset() {
-          clickDifferentiatorTimer.stop()
-          clickDifferentiatorTimer.invalidate = false
-        }
+      Timer {
+        id: dragDifferentiatorTimer
+
+        interval: Application.styleHints.startDragTime
       }
     }
   }

--- a/app/qml/map/MMMapCanvas.qml
+++ b/app/qml/map/MMMapCanvas.qml
@@ -118,7 +118,7 @@ Item {
       }
 
       function vectorDistance( a, b ) {
-        return Math.sqrt( Math.pow( a.x - b.x, 2 ), Math.pow( a.y - b.y, 2 ) )
+        return Math.sqrt( Math.pow( b.x - a.x, 2 ) + Math.pow( b.y - a.y, 2 ) )
       }
     }
   }


### PR DESCRIPTION
**Update, ready for review**

These things are fixed/added:
 - The formula for calculating vector distance was missing `+` 🤦🏻‍♂️ 😃  , resulting in wrong distances calculated when you dragged the map vertically 
 - Added distance threshold for double clicks - now the second click must be within a _threshold_ from the first point.
 - Added time elapsed threshold for detecting drag movement - sometimes, if you move a map just by a tiny bit to fit the point, you might not exceed the distance threshold to detect the movement as a drag. It would be detected as a simple tap. This caused unexpected actions while recording new/updating existing geometries. Now to detect the drag gesture we use a combination of a distance threshold and a time threshold (_"how long the tap lasted"_) 
 - Thresholds are now read from Qt built-in `Application.styleHints.xyz`

---

 - [x] Added distance threshold for double clicks
 - [x] Make the `drag.threshold` smaller when digitizing -> when a user is digitizing, they need to pan the map by small distances that sometimes do not meet the `drag.threshold`. We need to find a better threshold and test it on all platforms.