### PR TITLE
remove deprecated QGIS API for writeAsVectorFormatV2

### DIFF
--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -58,18 +58,16 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir, QList
   options.driverName = QStringLiteral( "GPKG" );
   options.layerName = layerName;
   options.fileEncoding = QStringLiteral( "UTF-8" );
-  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( projectGpkgPath, predefinedFields, Qgis::WkbType::PointZ, layerCrs, QgsCoordinateTransformContext(), options ) );
-
 
   QString errorMessage;
-  QgsVectorFileWriter::writeAsVectorFormatV2(
+  QgsVectorFileWriter::writeAsVectorFormatV3(
     layer,
     projectGpkgPath,
     layer->transformContext(),
     options,
+    &errorMessage,
     nullptr,
-    nullptr,
-    &errorMessage );
+    nullptr );
 
   // Check and configure layer
   QgsVectorLayer *l = new QgsVectorLayer( projectGpkgPath, layerName, "ogr" );


### PR DESCRIPTION
fix #1613 

Replace deprecated QGIS API writeAsVectorFormatV2 with writeAsVectorFormatV3 (it has different position for error code in  arguments)

also removed artificial call to `QgsVectorFileWriter::create`, it should not be used at all when `writeAsVectorFormatV3` is used. This also removes bunch of warnings like `ERROR 1: sqlite3_exec ...` visible on desktop from the initial implementation https://github.com/MerginMaps/input/pull/1103

https://github.com/qgis/QGIS/blob/1f1e8b5de70a8a1c1e6a639f08fd15b9aeea6f8b/src/core/qgsvectorfilewriter.h#L663