### PR TITLE
Fix position tracking (0,0) coordinates on Android - fix locale when writing decimals

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
+++ b/app/android/src/uk/co/lutraconsulting/PositionTrackingService.java
@@ -28,6 +28,7 @@ import android.location.LocationListener;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Locale;
 
 import uk.co.lutraconsulting.PositionTrackingBroadcastMiddleware;
 
@@ -230,7 +231,7 @@ public class PositionTrackingService extends Service implements LocationListener
     public void onLocationChanged( Location location ) {
 
         long currentTimeSeconds = System.currentTimeMillis() / 1000; // UTC time
-        String positionUpdate = String.format("%f %f %f %d\n", location.getLongitude(), location.getLatitude(), location.getAltitude(), currentTimeSeconds);
+        String positionUpdate = String.format(Locale.US, "%f %f %f %d\n", location.getLongitude(), location.getLatitude(), location.getAltitude(), currentTimeSeconds);
 
         try {
             if ( positionUpdatesStream != null ) {


### PR DESCRIPTION
🫢 Java's `String::format` uses a default locale when no locale is provided to it. It means that for US/UK locale it used `.` as the decimal separator. However, for example for `SK`, it used `,` -> Qt was unable to parse double with such decimal separator aaaand 💥

We will use the common `Locale.US` for writing doubles. A workaround until this bug is released is to change the system language to English 🇬🇧🇺🇸 ... or some other place where they use `.` as decimal separator

Resolves #2781 

See https://developer.android.com/reference/java/util/Locale#default_locale:~:text=Be%20wary%20of%20the%20default%20locale

I checked other occurrences of `String::format` but they look alright.