### PR TITLE
Fixed feature list - used replace function always for a string

### DIFF
--- a/app/qml/layers/FeaturesListPageV2.qml
+++ b/app/qml/layers/FeaturesListPageV2.qml
@@ -89,7 +89,7 @@ Page {
 
           color: InputStyle.fontColor
           font.bold: true
-          text: model.display.replace(/\n/g, ' ')
+          text: model.display.toString().replace(/\n/g, ' ')
 
           font.pixelSize: InputStyle.fontPixelSizeNormal
 

--- a/app/qml/layers/FeaturesListPageV2.qml
+++ b/app/qml/layers/FeaturesListPageV2.qml
@@ -89,7 +89,7 @@ Page {
 
           color: InputStyle.fontColor
           font.bold: true
-          text: model.display.toString().replace(/\n/g, ' ')
+          text: model.display?.toString()?.replace(/\n/g, ' ') ?? ''
 
           font.pixelSize: InputStyle.fontPixelSizeNormal
 


### PR DESCRIPTION
The problem was when the replace function was called from a number and not from a string
Fixes: #2871 