### PR TITLE
WIP: Some investigations with Qt 6.5.3 [DO NOT MERGE]

### DIFF
--- a/app/qml/PanelItem.qml
+++ b/app/qml/PanelItem.qml
@@ -12,8 +12,8 @@ import "."  // import InputStyle singleton
 
 Rectangle {
     id: root
-    height: InputStyle.rowHeight
-    width: parent.width
+    // height: InputStyle.rowHeight
+    // width: parent.width
     color: InputStyle.clrPanelMain
 
     property string text: ""

--- a/app/qml/SettingsComboBoxItem.qml
+++ b/app/qml/SettingsComboBoxItem.qml
@@ -18,7 +18,6 @@ import "."  // import InputStyle singleton
 Rectangle {
   id: root
 
-  height: InputStyle.settingsPanelActionable
   color: InputStyle.clrPanelMain
 
   property int value

--- a/app/qml/SettingsHeaderItem.qml
+++ b/app/qml/SettingsHeaderItem.qml
@@ -14,8 +14,7 @@ import "."  // import InputStyle singleton
 
 Rectangle {
   id: root
-  height: InputStyle.rowHeight
-  width: parent.width
+
   color: InputStyle.clrPanelMain
 
   property string text: ""

--- a/app/qml/SettingsNumberItem.qml
+++ b/app/qml/SettingsNumberItem.qml
@@ -15,7 +15,6 @@ import "."  // import InputStyle singleton
 Rectangle {
     id: root
 
-    height: InputStyle.settingsPanelActionable
     color: InputStyle.clrPanelMain
 
     property double value

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -89,21 +89,23 @@ Item {
           color: InputStyle.panelBackgroundDark
         }
 
-        Column {
+        ColumnLayout {
           id: settingListContent
           anchors.fill: parent
           spacing: 1
 
           // Header "GPS"
           PanelItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
             color: InputStyle.panelBackgroundLight
             text: qsTr("GPS")
             bold: true
           }
 
           PanelItem {
-            height: root.rowHeight
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
             color: InputStyle.clrPanelMain
             text: qsTr("Follow GPS with map")
 
@@ -124,8 +126,9 @@ Item {
           }
 
           PanelItem {
-            height: root.rowHeight
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             color: InputStyle.clrPanelMain
             text: qsTr("GPS accuracy")
 
@@ -180,8 +183,8 @@ Item {
           }
 
           PanelItem {
-            height: root.rowHeight
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
             text: qsTr("Accuracy threshold")
 
             MouseArea {
@@ -208,8 +211,8 @@ Item {
           }
 
           PanelItem {
-            height: root.rowHeight
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
             text: qsTr("Show accuracy warning")
 
             SettingsSwitch {
@@ -229,8 +232,8 @@ Item {
           }
 
           PanelItem {
-            height: root.rowHeight
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
             color: InputStyle.clrPanelMain
             text: qsTr("Select GPS receiver")
 
@@ -241,7 +244,8 @@ Item {
           }
 
           SettingsNumberItem {
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: InputStyle.settingsPanelActionable
 
             title: qsTr("GPS antenna height")
             description: qsTr("Includes pole height and GPS receiver's antenna height")
@@ -255,12 +259,16 @@ Item {
 
           // Header "Streaming mode"
           SettingsHeaderItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             color: InputStyle.panelBackgroundLight
             text: qsTr("Streaming mode")
           }
 
           SettingsComboBoxItem {
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: InputStyle.settingsPanelActionable
 
             title: qsTr("Interval type")
             description: qsTr("Choose action when to add a new point")
@@ -272,7 +280,8 @@ Item {
           }
 
           SettingsNumberItem {
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: InputStyle.settingsPanelActionable
 
             title: qsTr("Line rec. interval")
             description: __appSettings.intervalType === StreamingIntervalType.Distance ? qsTr("in meters") : qsTr("in seconds")
@@ -286,14 +295,18 @@ Item {
 
           // Header "Recording"
           PanelItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             color: InputStyle.panelBackgroundLight
             text: qsTr("Recording")
             bold: true
           }
 
           PanelItem {
-            height: root.rowHeight
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             color: InputStyle.clrPanelMain
             text: qsTr("Reuse last value option")
 
@@ -314,8 +327,9 @@ Item {
           }
 
           PanelItem {
-            height: root.rowHeight
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             color: InputStyle.clrPanelMain
             text: qsTr( "Automatically sync changes" )
 
@@ -337,6 +351,9 @@ Item {
 
           // Delimeter
           PanelItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             color: InputStyle.panelBackgroundLight
             text: ""
             height: root.rowHeight / 3
@@ -344,6 +361,9 @@ Item {
 
           // App info
           PanelItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             text: qsTr("About")
             MouseArea {
               anchors.fill: parent
@@ -362,6 +382,9 @@ Item {
 
           // Privacy Policy
           PanelItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             text: qsTr("Privacy policy")
             MouseArea {
               anchors.fill: parent
@@ -371,6 +394,9 @@ Item {
 
           // Terms of Service
           PanelItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             text: qsTr("Terms of service")
             MouseArea {
               anchors.fill: parent
@@ -380,6 +406,9 @@ Item {
 
           // Debug/Logging
           PanelItem {
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.rowHeight
+
             text: qsTr("Diagnostic log")
             MouseArea {
               anchors.fill: parent

--- a/app/workspacesproxymodel.cpp
+++ b/app/workspacesproxymodel.cpp
@@ -31,6 +31,13 @@ void WorkspacesProxyModel::setSearchExpression( QString searchExpression )
 
   mSearchExpression = searchExpression;
   setFilterFixedString( mSearchExpression );
+
+  // for some reason in Qt 6.5.3 QML Repeater does not
+  // delete all items that are removed from proxy model
+  // immediately without invalidate() command called
+  // see https://github.com/MerginMaps/input/issues/2893
+  invalidate();
+
   emit searchExpressionChanged( mSearchExpression );
 }
 


### PR DESCRIPTION
Some investigations with Qt 6.5.3 on iOS

https://github.com/MerginMaps/input/issues/2893
- `Repeater` misbehaves, when you filter in Q sort model, the change of rowCount() is not applied to repeater, so it will have some zombie elements. Interestigly `beginModelReset/endModelReset` fixes it, or also `invalidate()` calls
(fixed in this PR atm)

https://github.com/MerginMaps/input/issues/2892
- this is `ScollView -> ColumnLayout`, scrolling is possible but always pan back to top - not sure why
- it works if I remove `Repeater` and add there only simple elements 
- it looks `Repeater` may have 0 `implicitHeight`
(NOT fixed in this PR atm)
 
https://github.com/MerginMaps/input/issues/2887
- it looks like `ScrollView -> Column` is not possible to scroll on iOS, replacing with ColumnLayout enables scrolling
(somewhat fixed in this PR atm)
- we have also this is the project errors dialog and maybe somewhere else too